### PR TITLE
Various fixes for running e2e tests locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ jobs:
       # We enable RBAC on the cluster too, to test the RBAC in Navigators chart
       - sudo -E CHANGE_MINIKUBE_NONE_USER=true minikube start --vm-driver=none --kubernetes-version="$KUBERNETES_VERSION" --extra-config=apiserver.Authorization.Mode=RBAC
       - while true; do if kubectl get nodes; then break; fi; echo "Waiting 5s for kubernetes to be ready..."; sleep 5; done
-      # Fix problems with kube-dns + rbac
-      - kubectl create serviceaccount --namespace kube-system kube-dns
       - make BUILD_TAG=latest build e2e-test
 
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ jobs:
       # Create a cluster. We do this as root as we are using the 'docker' driver.
       # We enable RBAC on the cluster too, to test the RBAC in Navigators chart
       - sudo -E CHANGE_MINIKUBE_NONE_USER=true minikube start --vm-driver=none --kubernetes-version="$KUBERNETES_VERSION" --extra-config=apiserver.Authorization.Mode=RBAC
-      - while true; do if kubectl get nodes; then break; fi; echo "Waiting 5s for kubernetes to be ready..."; sleep 5; done
       - make BUILD_TAG=latest build e2e-test
 
     - stage: test

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -47,8 +47,6 @@ function fail_test() {
     kubectl describe svc
     kubectl get apiservice -o yaml
     kubectl describe apiservice
-    kubectl logs -c apiserver -l app=navigator,component=apiserver
-    kubectl logs -c controller -l app=navigator,component=controller
     exit 1
 }
 

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -66,7 +66,7 @@ function apiversion_ready() {
 }
 
 echo "Waiting for navigator API version to be registered"
-retry TIMEOUT=30 apiversion_ready
+retry TIMEOUT=600 apiversion_ready
 
 kubectl api-versions
 

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -19,12 +19,6 @@ source "${SCRIPT_DIR}/libe2e.sh"
 helm delete --purge "${RELEASE_NAME}" || true
 kube_delete_namespace_and_wait "${USER_NAMESPACE}"
 
-echo "Waiting up to 10 minutes for Kubernetes to be ready..."
-retry TIMEOUT=600 kubectl get nodes
-
-echo "Waiting for tiller to be ready..."
-retry TIMEOUT=60 helm version
-
 echo "Installing navigator..."
 helm install --wait --name "${RELEASE_NAME}" contrib/charts/navigator \
         --set apiserver.image.pullPolicy=Never \

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -16,10 +16,7 @@ mkdir -p $TEST_DIR
 
 source "${SCRIPT_DIR}/libe2e.sh"
 
-helm delete --purge "${RELEASE_NAME}" || true
-kube_delete_namespace_and_wait "${USER_NAMESPACE}"
-
-echo "Waiting up to 5 minutes for Kubernetes to be ready..."
+echo "Waiting up to 10 minutes for Kubernetes to be ready..."
 retry TIMEOUT=600 kubectl get nodes
 
 echo "Installing helm..."
@@ -92,3 +89,6 @@ items:
     apiGroup: rbac.authorization.k8s.io
 EOF
 helm init --service-account=tiller
+
+echo "Waiting for tiller to be ready..."
+retry TIMEOUT=60 helm version

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 set -eux
 
-NAVIGATOR_NAMESPACE="navigator"
-USER_NAMESPACE="navigator-e2e-database1"
-RELEASE_NAME="nav-e2e"
-
-ROOT_DIR="$(git rev-parse --show-toplevel)"
 SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
-CONFIG_DIR=$(mktemp -d -t navigator-e2e.XXXXXXXXX)
-mkdir -p $CONFIG_DIR
-CERT_DIR="$CONFIG_DIR/certs"
-mkdir -p $CERT_DIR
-TEST_DIR="$CONFIG_DIR/tmp"
-mkdir -p $TEST_DIR
 
 source "${SCRIPT_DIR}/libe2e.sh"
 

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -14,7 +14,13 @@ apiVersion: v1
 kind: List
 items:
 
-### Fix kube-dns ###
+### Fix kube-dns RBAC issues ###
+# Create a ServiceAccount for kube-dns to use
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: kube-dns
+    namespace: kube-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION
* Simplify the navigator_ready function to only check for api-versions
* Tidy up the e2e prepare script (remove duplication and unused variables)
* Remove operations from travis.yaml which are duplicated in the e2e prepare script.


Regarding the original problems that I reported in https://gitlab.jetstack.net/marshal/navigator/issues/27

> On my local Minikube, the navigator APIs take a long time to be registered...up to 5 minutes.

This seems to be caused by kube-dns restarting due to RBAC until its service account has been created.
If I wait for kube-dns to settle down the API appears quickly and tests run reliably.

And this problem is exacerbated by Disk IO failures inside the minikube virtualbox VM.

I switched to using the kvm driver and now the tests pass reliably.

> Additionally the check for Deployment.status.readyReplicas no longer works.

Maybe this was caused by my using kubectl 1.6?
I upgraded to `kubectl v1.8` and the readyReplicas attribute is now reported, but nevertheless, I've modified the code to simply check for the availability of the navigator API.

