### PR TITLE
Prepare for moving to jetstack org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+go_import_path: github.com/jetstack/navigator
+
 jobs:
   include:
     - stage: test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINDIR        ?= bin
 HACK_DIR     ?= hack
-NAVIGATOR_PKG = github.com/jetstack-experimental/navigator
+NAVIGATOR_PKG = github.com/jetstack/navigator
 
 TYPES_FILES      = $(shell find pkg/apis -name types.go)
 

--- a/cmd/apiserver/start.go
+++ b/cmd/apiserver/start.go
@@ -28,10 +28,10 @@ import (
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	// "k8s.io/sample-apiserver/pkg/admission/plugin/banflunder"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/apiserver"
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion"
-	informers "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apiserver"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/internalversion"
+	informers "github.com/jetstack/navigator/pkg/client/informers/internalversion"
 )
 
 const defaultEtcdPathPrefix = "/registry/navigator.jetstack.io"

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -17,11 +17,11 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/jetstack-experimental/navigator/cmd/controller/app/options"
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	intscheme "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/scheme"
-	"github.com/jetstack-experimental/navigator/pkg/controllers"
-	"github.com/jetstack-experimental/navigator/pkg/kube"
+	"github.com/jetstack/navigator/cmd/controller/app/options"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	intscheme "github.com/jetstack/navigator/pkg/client/clientset/versioned/scheme"
+	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/kube"
 )
 
 const controllerAgentName = "navigator-controller"

--- a/cmd/controller/start.go
+++ b/cmd/controller/start.go
@@ -8,9 +8,9 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/jetstack-experimental/navigator/cmd/controller/app"
-	"github.com/jetstack-experimental/navigator/cmd/controller/app/options"
-	_ "github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch"
+	"github.com/jetstack/navigator/cmd/controller/app"
+	"github.com/jetstack/navigator/cmd/controller/app/options"
+	_ "github.com/jetstack/navigator/pkg/controllers/elasticsearch"
 )
 
 type NavigatorControllerOptions struct {

--- a/cmd/pilot-elasticsearch/main.go
+++ b/cmd/pilot-elasticsearch/main.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/util/logs"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot"
 )
 
 func main() {

--- a/cmd/pilot-elasticsearch/pilot.go
+++ b/cmd/pilot-elasticsearch/pilot.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/jetstack-experimental/navigator/pkg/pilot/elasticsearch/v5"
+	"github.com/jetstack/navigator/pkg/pilot/elasticsearch/v5"
 	"github.com/spf13/cobra"
 	"io"
 )

--- a/hack/update-client-gen.sh
+++ b/hack/update-client-gen.sh
@@ -10,7 +10,7 @@ SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
 ${CODEGEN_PKG}/generate-internal-groups.sh "deepcopy,defaulter,client,informer,lister" \
-  github.com/jetstack-experimental/navigator/pkg/client github.com/jetstack-experimental/navigator/pkg/apis github.com/jetstack-experimental/navigator/pkg/apis \
+  github.com/jetstack/navigator/pkg/client github.com/jetstack/navigator/pkg/apis github.com/jetstack/navigator/pkg/apis \
   navigator:v1alpha1 \
   --output-base "${GOPATH}/src/" \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
@@ -19,7 +19,7 @@ ${CODEGEN_PKG}/generate-internal-groups.sh "deepcopy,defaulter,client,informer,l
 # flag to not include k8s.io/kubernetes packages (https://github.com/kubernetes/kubernetes/issues/54301)
 
 ${CODEGEN_PKG}/generate-internal-groups.sh "conversion" \
-  github.com/jetstack-experimental/navigator/pkg/client github.com/jetstack-experimental/navigator/pkg/apis github.com/jetstack-experimental/navigator/pkg/apis \
+  github.com/jetstack/navigator/pkg/client github.com/jetstack/navigator/pkg/apis github.com/jetstack/navigator/pkg/apis \
   navigator:v1alpha1 \
   --output-base "${GOPATH}/src/" \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt \

--- a/labels.yaml
+++ b/labels.yaml
@@ -1,5 +1,5 @@
 ---
-repo: jetstack-experimental/navigator
+repo: jetstack/navigator
 labels:
 - name: approved
   color: 0ffa16

--- a/pkg/apis/navigator/install/install.go
+++ b/pkg/apis/navigator/install/install.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 // Install registers the API group and adds types to a scheme

--- a/pkg/apis/navigator/v1alpha1/doc.go
+++ b/pkg/apis/navigator/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/jetstack-experimental/navigator/pkg/apis/navigator
+// +k8s:conversion-gen=github.com/jetstack/navigator/pkg/apis/navigator
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 

--- a/pkg/apis/navigator/v1alpha1/register.go
+++ b/pkg/apis/navigator/v1alpha1/register.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -27,12 +27,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/install"
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	informers "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion"
-	esclusterstorage "github.com/jetstack-experimental/navigator/pkg/registry/navigator/escluster"
-	pilotstorage "github.com/jetstack-experimental/navigator/pkg/registry/navigator/pilot"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator/install"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	informers "github.com/jetstack/navigator/pkg/client/informers/internalversion"
+	esclusterstorage "github.com/jetstack/navigator/pkg/registry/navigator/escluster"
+	pilotstorage "github.com/jetstack/navigator/pkg/registry/navigator/pilot"
 )
 
 var (

--- a/pkg/client/clientset/internalversion/clientset.go
+++ b/pkg/client/clientset/internalversion/clientset.go
@@ -17,7 +17,7 @@ package internalversion
 
 import (
 	glog "github.com/golang/glog"
-	navigatorinternalversion "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion/typed/navigator/internalversion"
+	navigatorinternalversion "github.com/jetstack/navigator/pkg/client/clientset/internalversion/typed/navigator/internalversion"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/internalversion/fake/clientset_generated.go
+++ b/pkg/client/clientset/internalversion/fake/clientset_generated.go
@@ -16,9 +16,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion"
-	navigatorinternalversion "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion/typed/navigator/internalversion"
-	fakenavigatorinternalversion "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion/typed/navigator/internalversion/fake"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/internalversion"
+	navigatorinternalversion "github.com/jetstack/navigator/pkg/client/clientset/internalversion/typed/navigator/internalversion"
+	fakenavigatorinternalversion "github.com/jetstack/navigator/pkg/client/clientset/internalversion/typed/navigator/internalversion/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/internalversion/fake/register.go
+++ b/pkg/client/clientset/internalversion/fake/register.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	navigatorinternalversion "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	navigatorinternalversion "github.com/jetstack/navigator/pkg/apis/navigator"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/internalversion/scheme/register.go
+++ b/pkg/client/clientset/internalversion/scheme/register.go
@@ -16,7 +16,7 @@ limitations under the License.
 package scheme
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator/install"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator/install"
 	announced "k8s.io/apimachinery/pkg/apimachinery/announced"
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/client/clientset/internalversion/typed/navigator/internalversion/elasticsearchcluster.go
+++ b/pkg/client/clientset/internalversion/typed/navigator/internalversion/elasticsearchcluster.go
@@ -16,8 +16,8 @@ limitations under the License.
 package internalversion
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	scheme "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion/scheme"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
+	scheme "github.com/jetstack/navigator/pkg/client/clientset/internalversion/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/internalversion/typed/navigator/internalversion/fake/fake_elasticsearchcluster.go
+++ b/pkg/client/clientset/internalversion/typed/navigator/internalversion/fake/fake_elasticsearchcluster.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/internalversion/typed/navigator/internalversion/fake/fake_navigator_client.go
+++ b/pkg/client/clientset/internalversion/typed/navigator/internalversion/fake/fake_navigator_client.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	internalversion "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion/typed/navigator/internalversion"
+	internalversion "github.com/jetstack/navigator/pkg/client/clientset/internalversion/typed/navigator/internalversion"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/internalversion/typed/navigator/internalversion/fake/fake_pilot.go
+++ b/pkg/client/clientset/internalversion/typed/navigator/internalversion/fake/fake_pilot.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/internalversion/typed/navigator/internalversion/navigator_client.go
+++ b/pkg/client/clientset/internalversion/typed/navigator/internalversion/navigator_client.go
@@ -16,7 +16,7 @@ limitations under the License.
 package internalversion
 
 import (
-	"github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion/scheme"
+	"github.com/jetstack/navigator/pkg/client/clientset/internalversion/scheme"
 	rest "k8s.io/client-go/rest"
 )
 

--- a/pkg/client/clientset/internalversion/typed/navigator/internalversion/pilot.go
+++ b/pkg/client/clientset/internalversion/typed/navigator/internalversion/pilot.go
@@ -16,8 +16,8 @@ limitations under the License.
 package internalversion
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	scheme "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion/scheme"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
+	scheme "github.com/jetstack/navigator/pkg/client/clientset/internalversion/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -17,7 +17,7 @@ package versioned
 
 import (
 	glog "github.com/golang/glog"
-	navigatorv1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/typed/navigator/v1alpha1"
+	navigatorv1alpha1 "github.com/jetstack/navigator/pkg/client/clientset/versioned/typed/navigator/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -16,9 +16,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	navigatorv1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/typed/navigator/v1alpha1"
-	fakenavigatorv1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/typed/navigator/v1alpha1/fake"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	navigatorv1alpha1 "github.com/jetstack/navigator/pkg/client/clientset/versioned/typed/navigator/v1alpha1"
+	fakenavigatorv1alpha1 "github.com/jetstack/navigator/pkg/client/clientset/versioned/typed/navigator/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	navigatorv1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	navigatorv1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -16,7 +16,7 @@ limitations under the License.
 package scheme
 
 import (
-	navigatorv1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	navigatorv1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/navigator/v1alpha1/elasticsearchcluster.go
+++ b/pkg/client/clientset/versioned/typed/navigator/v1alpha1/elasticsearchcluster.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	scheme "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	scheme "github.com/jetstack/navigator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/navigator/v1alpha1/fake/fake_elasticsearchcluster.go
+++ b/pkg/client/clientset/versioned/typed/navigator/v1alpha1/fake/fake_elasticsearchcluster.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/navigator/v1alpha1/fake/fake_navigator_client.go
+++ b/pkg/client/clientset/versioned/typed/navigator/v1alpha1/fake/fake_navigator_client.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/typed/navigator/v1alpha1"
+	v1alpha1 "github.com/jetstack/navigator/pkg/client/clientset/versioned/typed/navigator/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/versioned/typed/navigator/v1alpha1/fake/fake_pilot.go
+++ b/pkg/client/clientset/versioned/typed/navigator/v1alpha1/fake/fake_pilot.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/navigator/v1alpha1/navigator_client.go
+++ b/pkg/client/clientset/versioned/typed/navigator/v1alpha1/navigator_client.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/client/clientset/versioned/scheme"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )

--- a/pkg/client/clientset/versioned/typed/navigator/v1alpha1/pilot.go
+++ b/pkg/client/clientset/versioned/typed/navigator/v1alpha1/pilot.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	scheme "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	scheme "github.com/jetstack/navigator/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -19,9 +19,9 @@ limitations under the License.
 package externalversions
 
 import (
-	versioned "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions/internalinterfaces"
-	navigator "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions/navigator"
+	versioned "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/externalversions/internalinterfaces"
+	navigator "github.com/jetstack/navigator/pkg/client/informers/externalversions/navigator"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -20,7 +20,7 @@ package externalversions
 
 import (
 	"fmt"
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -19,7 +19,7 @@ limitations under the License.
 package internalinterfaces
 
 import (
-	versioned "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
+	versioned "github.com/jetstack/navigator/pkg/client/clientset/versioned"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	time "time"

--- a/pkg/client/informers/externalversions/navigator/interface.go
+++ b/pkg/client/informers/externalversions/navigator/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package navigator
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions/navigator/v1alpha1"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/jetstack/navigator/pkg/client/informers/externalversions/navigator/v1alpha1"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/navigator/v1alpha1/elasticsearchcluster.go
+++ b/pkg/client/informers/externalversions/navigator/v1alpha1/elasticsearchcluster.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	navigator_v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	versioned "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/listers/navigator/v1alpha1"
+	navigator_v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	versioned "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/navigator/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/navigator/v1alpha1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/navigator/v1alpha1/pilot.go
+++ b/pkg/client/informers/externalversions/navigator/v1alpha1/pilot.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	navigator_v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	versioned "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/listers/navigator/v1alpha1"
+	navigator_v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	versioned "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/internalversion/factory.go
+++ b/pkg/client/informers/internalversion/factory.go
@@ -19,9 +19,9 @@ limitations under the License.
 package internalversion
 
 import (
-	internalversion "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion"
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion/internalinterfaces"
-	navigator "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion/navigator"
+	internalversion "github.com/jetstack/navigator/pkg/client/clientset/internalversion"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/internalversion/internalinterfaces"
+	navigator "github.com/jetstack/navigator/pkg/client/informers/internalversion/navigator"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/informers/internalversion/generic.go
+++ b/pkg/client/informers/internalversion/generic.go
@@ -20,7 +20,7 @@ package internalversion
 
 import (
 	"fmt"
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/informers/internalversion/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/internalversion/internalinterfaces/factory_interfaces.go
@@ -19,7 +19,7 @@ limitations under the License.
 package internalinterfaces
 
 import (
-	internalversion "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion"
+	internalversion "github.com/jetstack/navigator/pkg/client/clientset/internalversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	time "time"

--- a/pkg/client/informers/internalversion/navigator/interface.go
+++ b/pkg/client/informers/internalversion/navigator/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package navigator
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion/internalinterfaces"
-	internalversion "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion/navigator/internalversion"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/internalversion/internalinterfaces"
+	internalversion "github.com/jetstack/navigator/pkg/client/informers/internalversion/navigator/internalversion"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/internalversion/navigator/internalversion/elasticsearchcluster.go
+++ b/pkg/client/informers/internalversion/navigator/internalversion/elasticsearchcluster.go
@@ -19,10 +19,10 @@ limitations under the License.
 package internalversion
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	clientset_internalversion "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion"
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion/internalinterfaces"
-	internalversion "github.com/jetstack-experimental/navigator/pkg/client/listers/navigator/internalversion"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
+	clientset_internalversion "github.com/jetstack/navigator/pkg/client/clientset/internalversion"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/internalversion/internalinterfaces"
+	internalversion "github.com/jetstack/navigator/pkg/client/listers/navigator/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/internalversion/navigator/internalversion/interface.go
+++ b/pkg/client/informers/internalversion/navigator/internalversion/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion/internalinterfaces"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/internalversion/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/internalversion/navigator/internalversion/pilot.go
+++ b/pkg/client/informers/internalversion/navigator/internalversion/pilot.go
@@ -19,10 +19,10 @@ limitations under the License.
 package internalversion
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	clientset_internalversion "github.com/jetstack-experimental/navigator/pkg/client/clientset/internalversion"
-	internalinterfaces "github.com/jetstack-experimental/navigator/pkg/client/informers/internalversion/internalinterfaces"
-	internalversion "github.com/jetstack-experimental/navigator/pkg/client/listers/navigator/internalversion"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
+	clientset_internalversion "github.com/jetstack/navigator/pkg/client/clientset/internalversion"
+	internalinterfaces "github.com/jetstack/navigator/pkg/client/informers/internalversion/internalinterfaces"
+	internalversion "github.com/jetstack/navigator/pkg/client/listers/navigator/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/listers/navigator/internalversion/elasticsearchcluster.go
+++ b/pkg/client/listers/navigator/internalversion/elasticsearchcluster.go
@@ -19,7 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/navigator/internalversion/pilot.go
+++ b/pkg/client/listers/navigator/internalversion/pilot.go
@@ -19,7 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
-	navigator "github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	navigator "github.com/jetstack/navigator/pkg/apis/navigator"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/navigator/v1alpha1/elasticsearchcluster.go
+++ b/pkg/client/listers/navigator/v1alpha1/elasticsearchcluster.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/navigator/v1alpha1/pilot.go
+++ b/pkg/client/listers/navigator/v1alpha1/pilot.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/controllers/context.go
+++ b/pkg/controllers/context.go
@@ -4,8 +4,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	"github.com/jetstack-experimental/navigator/pkg/kube"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	"github.com/jetstack/navigator/pkg/kube"
 )
 
 type Context struct {

--- a/pkg/controllers/elasticsearch/cluster_control.go
+++ b/pkg/controllers/elasticsearch/cluster_control.go
@@ -7,12 +7,12 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/configmap"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/nodepool"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/service"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/serviceaccount"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/configmap"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/nodepool"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/service"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/serviceaccount"
 )
 
 const (

--- a/pkg/controllers/elasticsearch/configmap/controller.go
+++ b/pkg/controllers/elasticsearch/configmap/controller.go
@@ -9,7 +9,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 type Interface interface {

--- a/pkg/controllers/elasticsearch/configmap/resources.go
+++ b/pkg/controllers/elasticsearch/configmap/resources.go
@@ -4,8 +4,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/util"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
 )
 
 func esConfigConfigMap(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.ElasticsearchClusterNodePool) *apiv1.ConfigMap {

--- a/pkg/controllers/elasticsearch/elasticsearch.go
+++ b/pkg/controllers/elasticsearch/elasticsearch.go
@@ -20,16 +20,16 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	informerv1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions/navigator/v1alpha1"
-	listersv1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/listers/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/controllers"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/configmap"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/nodepool"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/service"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/serviceaccount"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	informerv1alpha1 "github.com/jetstack/navigator/pkg/client/informers/externalversions/navigator/v1alpha1"
+	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/configmap"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/nodepool"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/service"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/serviceaccount"
 )
 
 type ElasticsearchController struct {

--- a/pkg/controllers/elasticsearch/nodepool/controller.go
+++ b/pkg/controllers/elasticsearch/nodepool/controller.go
@@ -16,10 +16,10 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/golang/glog"
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	listersv1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/listers/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/util"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
 )
 
 type Interface interface {

--- a/pkg/controllers/elasticsearch/nodepool/resources.go
+++ b/pkg/controllers/elasticsearch/nodepool/resources.go
@@ -10,8 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/util"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
 )
 
 const (

--- a/pkg/controllers/elasticsearch/service/controller.go
+++ b/pkg/controllers/elasticsearch/service/controller.go
@@ -9,7 +9,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 type Interface interface {

--- a/pkg/controllers/elasticsearch/service/resources.go
+++ b/pkg/controllers/elasticsearch/service/resources.go
@@ -5,8 +5,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/util"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
 )
 
 func discoveryService(c *v1alpha1.ElasticsearchCluster) *apiv1.Service {

--- a/pkg/controllers/elasticsearch/serviceaccount/controller.go
+++ b/pkg/controllers/elasticsearch/serviceaccount/controller.go
@@ -7,8 +7,8 @@ import (
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/util"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
 )
 
 type defaultElasticsearchClusterServiceAccountControl struct {

--- a/pkg/controllers/elasticsearch/serviceaccount/resources.go
+++ b/pkg/controllers/elasticsearch/serviceaccount/resources.go
@@ -4,8 +4,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/controllers/elasticsearch/util"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
 )
 
 func clusterServiceAccount(c *v1alpha1.ElasticsearchCluster) *apiv1.ServiceAccount {

--- a/pkg/controllers/elasticsearch/util/configmap.go
+++ b/pkg/controllers/elasticsearch/util/configmap.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 func ConfigMapName(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.ElasticsearchClusterNodePool) string {

--- a/pkg/controllers/elasticsearch/util/nodepool.go
+++ b/pkg/controllers/elasticsearch/util/nodepool.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	appslisters "k8s.io/client-go/listers/apps/v1beta1"
 
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	hashutil "github.com/jetstack-experimental/navigator/pkg/util/hash"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	hashutil "github.com/jetstack/navigator/pkg/util/hash"
 )
 
 const (

--- a/pkg/controllers/elasticsearch/util/service.go
+++ b/pkg/controllers/elasticsearch/util/service.go
@@ -3,7 +3,7 @@ package util
 import (
 	"fmt"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 func DiscoveryServiceName(c *v1alpha1.ElasticsearchCluster) string {

--- a/pkg/controllers/elasticsearch/util/serviceaccount.go
+++ b/pkg/controllers/elasticsearch/util/serviceaccount.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 func ServiceAccountName(c *v1alpha1.ElasticsearchCluster) string {

--- a/pkg/controllers/elasticsearch/util/util.go
+++ b/pkg/controllers/elasticsearch/util/util.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	v1alpha1 "github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 const (

--- a/pkg/pilot/elasticsearch/v5/controller.go
+++ b/pkg/pilot/elasticsearch/v5/controller.go
@@ -2,7 +2,7 @@ package v5
 
 import (
 	"fmt"
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 

--- a/pkg/pilot/elasticsearch/v5/install_plugin.go
+++ b/pkg/pilot/elasticsearch/v5/install_plugin.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 // InstallPlugins will install the plugins listed on the Pilot resource. It

--- a/pkg/pilot/elasticsearch/v5/options.go
+++ b/pkg/pilot/elasticsearch/v5/options.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	informers "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions"
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	informers "github.com/jetstack/navigator/pkg/client/informers/externalversions"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot"
 )
 
 const (

--- a/pkg/pilot/elasticsearch/v5/pilot.go
+++ b/pkg/pilot/elasticsearch/v5/pilot.go
@@ -8,9 +8,9 @@ import (
 	"gopkg.in/olivere/elastic.v5"
 	"k8s.io/client-go/tools/cache"
 
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	listersv1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/listers/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/hook"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/hook"
 )
 
 const (

--- a/pkg/pilot/elasticsearch/v5/probes.go
+++ b/pkg/pilot/elasticsearch/v5/probes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/probe"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/probe"
 )
 
 func (p *Pilot) ReadinessCheck() probe.Check {

--- a/pkg/pilot/elasticsearch/v5/process.go
+++ b/pkg/pilot/elasticsearch/v5/process.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 func (p *Pilot) CmdFunc(pilot *v1alpha1.Pilot) (*exec.Cmd, error) {

--- a/pkg/pilot/elasticsearch/v5/write_config.go
+++ b/pkg/pilot/elasticsearch/v5/write_config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 const (

--- a/pkg/pilot/genericpilot/controller.go
+++ b/pkg/pilot/genericpilot/controller.go
@@ -10,9 +10,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/hook"
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/process"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/hook"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/process"
 )
 
 const (

--- a/pkg/pilot/genericpilot/genericpilot.go
+++ b/pkg/pilot/genericpilot/genericpilot.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	listersv1alpha1 "github.com/jetstack-experimental/navigator/pkg/client/listers/navigator/v1alpha1"
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/process"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/process"
 )
 
 type GenericPilot struct {

--- a/pkg/pilot/genericpilot/healthz.go
+++ b/pkg/pilot/genericpilot/healthz.go
@@ -1,6 +1,6 @@
 package genericpilot
 
-import "github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/probe"
+import "github.com/jetstack/navigator/pkg/pilot/genericpilot/probe"
 
 func (g *GenericPilot) serveHealthz() {
 	// Start readiness checker

--- a/pkg/pilot/genericpilot/hook/hook.go
+++ b/pkg/pilot/genericpilot/hook/hook.go
@@ -3,7 +3,7 @@ package hook
 import (
 	"fmt"
 	"github.com/golang/glog"
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"sync"
 )
 

--- a/pkg/pilot/genericpilot/options.go
+++ b/pkg/pilot/genericpilot/options.go
@@ -17,13 +17,13 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator/v1alpha1"
-	clientset "github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned"
-	"github.com/jetstack-experimental/navigator/pkg/client/clientset/versioned/scheme"
-	informers "github.com/jetstack-experimental/navigator/pkg/client/informers/externalversions"
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/hook"
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/probe"
-	"github.com/jetstack-experimental/navigator/pkg/pilot/genericpilot/process"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	"github.com/jetstack/navigator/pkg/client/clientset/versioned/scheme"
+	informers "github.com/jetstack/navigator/pkg/client/informers/externalversions"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/hook"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/probe"
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/process"
 )
 
 const (

--- a/pkg/registry/navigator/escluster/etcd.go
+++ b/pkg/registry/navigator/escluster/etcd.go
@@ -18,8 +18,8 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	"github.com/jetstack-experimental/navigator/pkg/registry"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/registry"
 )
 
 // NewREST returns a RESTStorage object that will work against API services.

--- a/pkg/registry/navigator/escluster/strategy.go
+++ b/pkg/registry/navigator/escluster/strategy.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
 )
 
 func NewStrategy(typer runtime.ObjectTyper) esClusterStrategy {

--- a/pkg/registry/navigator/pilot/etcd.go
+++ b/pkg/registry/navigator/pilot/etcd.go
@@ -18,8 +18,8 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
-	"github.com/jetstack-experimental/navigator/pkg/registry"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/registry"
 )
 
 // NewREST returns a RESTStorage object that will work against API services.

--- a/pkg/registry/navigator/pilot/strategy.go
+++ b/pkg/registry/navigator/pilot/strategy.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"github.com/jetstack-experimental/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator"
 )
 
 func NewStrategy(typer runtime.ObjectTyper) pilotStrategy {


### PR DESCRIPTION
**What this PR does / why we need it**:

Prepares the repository for moving to github.com/jetstack/navigator. This PR does *not* update the image repo to use quay.io - that will come in a later follow up PR, after the move.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
