### PR TITLE
Fix glog parse error in apiserver and controller logs

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -35,6 +35,7 @@ func main() {
 	stopCh := genericapiserver.SetupSignalHandler()
 	cmd := NewCommandStartNavigatorServer(os.Stdout, os.Stderr, stopCh)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	flag.CommandLine.Parse([]string{})
 	if err := cmd.Execute(); err != nil {
 		glog.Fatal(err)
 	}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -37,6 +37,7 @@ func main() {
 	stopCh := genericapiserver.SetupSignalHandler()
 	cmd := NewCommandStartNavigatorController(os.Stdout, os.Stderr, stopCh)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	flag.CommandLine.Parse([]string{})
 	if err := cmd.Execute(); err != nil {
 		glog.Fatal(err)
 	}


### PR DESCRIPTION
A hack to prevent glog prefixing every message with `ERROR: logging before flag.Parse`

The logs now look like:

```
cat apiserver.log
I1031 14:26:20.233059       1 serving.go:283] Generated self-signed cert (apiserver.local.config/certificates/apiserver.crt, apiserver.local.config/certificates/apiserver.key)
I1031 14:26:20.902689       1 serve.go:85] Serving securely on 0.0.0.0:443
```

And

```
head controller.log 
I1031 14:26:19.580479       1 controller.go:102] Creating event broadcaster
I1031 14:26:19.581139       1 leaderelection.go:174] attempting to acquire leader lease...
I1031 14:26:19.581222       1 round_trippers.go:417] curl -k -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: navigator-controller/v1.8.2 (linux/amd64) kubernetes/$Format/leader-election" -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im5hdi1lMmUtbmF2aWdhdG9yLWNvbnRyb2xsZXItdG9rZW4tejk0NW0iLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibmF2LWUyZS1uYXZpZ2F0b3ItY29udHJvbGxlciIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6Ijc1MTAxZWVmLWJlNDctMTFlNy04ODljLTUyNTQwMGI2MDhmYSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0Om5hdi1lMmUtbmF2aWdhdG9yLWNvbnRyb2xsZXIifQ.sQ1Rv_9Yfa_KFsGlD9f8td5OqsaCpBJzzYtpB67kXuJss_t9xu98mcqw4RBqpxxDFNu5vADKpOZlP4_kJlf8OOaEyn_IgdOVmeZxY7fN_nDk16aoEBNmn6D5thRZrXxkYGtBVKiuUqvGT0M6N8xcv1EnI_TBbnoXdxcmk4KNobKuYuBgLLmSu6zdDcLEvYtwNI0InvsMH36tfBNQpgULUR46uiGnMDXw0T3E-qLRuGPK723UZproTRG-HRk_HFZ4tEG5nIFAgkWXJzpynAgQ9thQp28CSue79ngzF1rByacpQEJH0R8sEHDTbK-csi3eOxGjpW44s6oMOG_ZERQQRw" https://10.0.0.1:443/api/v1/namespaces/kube-system/endpoints/navigator-controller
I1031 14:26:19.747554       1 round_trippers.go:436] GET https://10.0.0.1:443/api/v1/namespaces/kube-system/endpoints/navigator-controller 403 Forbidden in 166 milliseconds
I1031 14:26:19.747587       1 round_trippers.go:442] Response Headers:
I1031 14:26:19.747592       1 round_trippers.go:445]     Content-Type: text/plain
I1031 14:26:19.747597       1 round_trippers.go:445]     X-Content-Type-Options: nosniff
I1031 14:26:19.747600       1 round_trippers.go:445]     Content-Length: 118
I1031 14:26:19.747608       1 round_trippers.go:445]     Date: Tue, 31 Oct 2017 14:26:19 GMT
I1031 14:26:19.747633       1 request.go:836] Response Body: User "system:serviceaccount:default:nav-e2e-navigator-controller" cannot get endpoints in the namespace "kube-system".

```

The Pilot command already had this hack.

Note: Kubernetes solved this by pinning to an older version of glog which does not have this bug:
 * https://github.com/kubernetes/kubernetes/issues/17162

They also discuss switching to a better logging framework which I think we should consider too.


**Release note**:
```release-note
NONE
```


Fixes: #73 