### PR TITLE
Only run Travis-CI tests for PRs and when master branch changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,8 @@ jobs:
           mkdir -p ~/.docker && echo "${DOCKER_AUTH_CONFIG}" > ~/.docker/config.json && chmod 600 ~/.docker/config.json;
           make docker_push IMAGE_TAGS="${TRAVIS_COMMIT} latest";
         fi
+
+# Only run tests when master branch changes or when a PR branch is updated.
+branches:
+  only:
+  - master


### PR DESCRIPTION
Fixes: #76 

This PR should only run the Travis-CI tests once, for the PR not for the branch.

Should speed up the time it takes to approve and merge small PRs

**Release note**:
```release-note
NONE
```
