### PR TITLE
Run e2e tests against Kubernetes 1.8.0 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,17 @@ jobs:
       go: 1.8
       env:
       - KUBERNETES_VERSION=v1.7.0
+      - KUBERNETES_VERSION=v1.8.0
       script:
       - set -e
       - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin
       - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.21.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+      - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.23.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
       # Install nsenter
       - docker run -v /usr/local/bin:/hostbin quay.io/jetstack/ubuntu-nsenter cp /nsenter /hostbin/nsenter
       # Create a cluster. We do this as root as we are using the 'docker' driver.
       # We enable RBAC on the cluster too, to test the RBAC in Navigators chart
-      - sudo -E CHANGE_MINIKUBE_NONE_USER=true minikube start --vm-driver=none --kubernetes-version="$KUBERNETES_VERSION" --extra-config=apiserver.Authorization.Mode=RBAC
+      - sudo -E CHANGE_MINIKUBE_NONE_USER=true minikube start -v 100 --vm-driver=none --kubernetes-version="$KUBERNETES_VERSION" --extra-config=apiserver.Authorization.Mode=RBAC
       - while true; do if kubectl get nodes; then break; fi; echo "Waiting 5s for kubernetes to be ready..."; sleep 5; done
       # Fix problems with kube-dns + rbac
       - kubectl create serviceaccount --namespace kube-system kube-dns

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,37 @@
+dist: trusty
+
+language: go
+
+go: 1.8
+
 go_import_path: github.com/jetstack/navigator
+
+services:
+- docker
 
 jobs:
   include:
     - stage: test
-      dist: trusty
-      language: go
-      go: 1.8
       env:
-      - KUBERNETES_VERSION=v1.7.0
       - KUBERNETES_VERSION=v1.8.0
+      before_script:
+      - ./hack/install-e2e-dependencies.sh
       script:
-      - set -e
-      - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin
-      - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.23.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-      # Install nsenter
-      - docker run -v /usr/local/bin:/hostbin quay.io/jetstack/ubuntu-nsenter cp /nsenter /hostbin/nsenter
-      # Create a cluster. We do this as root as we are using the 'docker' driver.
-      # We enable RBAC on the cluster too, to test the RBAC in Navigators chart
-      - sudo -E CHANGE_MINIKUBE_NONE_USER=true minikube start -v 100 --vm-driver=none --kubernetes-version="$KUBERNETES_VERSION" --extra-config=apiserver.Authorization.Mode=RBAC
-      - while true; do if kubectl get nodes; then break; fi; echo "Waiting 5s for kubernetes to be ready..."; sleep 5; done
-      # Fix problems with kube-dns + rbac
-      - kubectl create serviceaccount --namespace kube-system kube-dns
       - make BUILD_TAG=latest build e2e-test
 
     - stage: test
-      dist: trusty
-      language: go
-      go: 1.8
+      env:
+      - KUBERNETES_VERSION=v1.7.0
+      before_script:
+      - ./hack/install-e2e-dependencies.sh
+      script:
+      - make BUILD_TAG=latest build e2e-test
+
+    - stage: test
       script:
       - make verify
 
     - stage: build
-      dist: trusty
-      services:
-      - docker
-      language: go
-      go: 1.8
       script:
       - make go_build docker_build
       - if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then

--- a/hack/install-e2e-dependencies.sh
+++ b/hack/install-e2e-dependencies.sh
@@ -1,0 +1,25 @@
+set -eux
+curl -Lo helm.tar.gz \
+     https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz
+tar xvf helm.tar.gz
+sudo mv linux-amd64/helm /usr/local/bin
+
+curl -Lo kubectl \
+     https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/
+
+curl -Lo minikube \
+     https://storage.googleapis.com/minikube/releases/v0.23.0/minikube-linux-amd64
+chmod +x minikube
+sudo mv minikube /usr/local/bin/
+
+docker run -v /usr/local/bin:/hostbin quay.io/jetstack/ubuntu-nsenter cp /nsenter /hostbin/nsenter
+
+# Create a cluster. We do this as root as we are using the 'docker' driver.
+# We enable RBAC on the cluster too, to test the RBAC in Navigators chart
+sudo -E CHANGE_MINIKUBE_NONE_USER=true minikube start \
+     -v 100 \
+     --vm-driver=none \
+     --kubernetes-version="$KUBERNETES_VERSION" \
+     --extra-config=apiserver.Authorization.Mode=RBAC


### PR DESCRIPTION
Fixes: #78 

**Release note**:
```release-note
Navigator is now tested on Kubernetes 1.8.0
```
