### PR TITLE
Add missing wait for ConfigMap informer to sync

### DIFF
--- a/pkg/controllers/elasticsearch/elasticsearch.go
+++ b/pkg/controllers/elasticsearch/elasticsearch.go
@@ -163,7 +163,14 @@ func NewElasticsearch(
 func (e *ElasticsearchController) Run(workers int, stopCh <-chan struct{}) error {
 	glog.Infof("Starting Elasticsearch controller")
 
-	if !cache.WaitForCacheSync(stopCh, e.esListerSynced, e.pilotListerSynced, e.statefulSetListerSynced, e.podListerSynced, e.serviceAccountListerSynced, e.serviceListerSynced) {
+	if !cache.WaitForCacheSync(stopCh,
+		e.esListerSynced,
+		e.pilotListerSynced,
+		e.statefulSetListerSynced,
+		e.podListerSynced,
+		e.serviceAccountListerSynced,
+		e.serviceListerSynced,
+		e.configMapListerSynced) {
 		return fmt.Errorf("timed out waiting for caches to sync")
 	}
 


### PR DESCRIPTION
Previously we did not wait for ConfigMaps to be synced before starting the controller

```release-note
NONE
```

/assign @wallrj 