### PR TITLE
Permit logging of events when RBAC is enabled

### DIFF
--- a/contrib/charts/navigator/templates/rbac.yaml
+++ b/contrib/charts/navigator/templates/rbac.yaml
@@ -6,7 +6,7 @@ items:
 {{- if not .Values.apiserver.rbacDisabled }}
 ### API Server ###
 # TODO: if this is just for namespace lifecycle admission, move to a generic role
-# the role for the apiserver 
+# the role for the apiserver
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRole
   metadata:
@@ -99,6 +99,9 @@ items:
     resources: ["endpoints"]
     verbs:     ["*"]
     resourceNames: ["navigator-controller"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs:     ["create", "update"]
 
 - apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- if not .Values.controller.namespace }}

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -46,6 +46,11 @@ function navigator_ready() {
     if ! kubectl get esc; then
         return 1
     fi
+    if ! kube_event_exists "kube-system" \
+         "navigator-controller:Endpoints:Normal:LeaderElection"
+    then
+        return 1
+    fi
     return 0
 }
 
@@ -88,6 +93,11 @@ function test_elasticsearchcluster() {
          --namespace "${USER_NAMESPACE}" \
          service es-demo; then
         fail_test "Navigator controller failed to create elasticsearchcluster service"
+    fi
+    if ! retry kube_event_exists "${USER_NAMESPACE}" \
+         "navigator-controller:ElasticsearchCluster:Normal:SuccessSync"
+    then
+        fail_test "Navigator controller failed to create SuccessSync event"
     fi
     if ! kubectl delete \
             --namespace "${USER_NAMESPACE}" \

--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -51,3 +51,17 @@ function kube_delete_namespace_and_wait() {
     kubectl delete namespace "${namespace}" || true
     retry TIMEOUT=300 not kubectl get namespace ${namespace}
 }
+
+function kube_event_exists() {
+    local namespace="${1}"
+    local event="${2}"
+    local go_template='{{range .items}}{{.source.component}}:{{.involvedObject.kind}}:{{.type}}:{{.reason}}{{"\n"}}{{end}}'
+    if kubectl get \
+               --namespace "${namespace}" \
+               events \
+               --output=go-template="${go_template}" \
+            | grep "^${event}$"; then
+        return 0
+    fi
+    return 1
+}

--- a/pkg/controllers/elasticsearch/cluster_control.go
+++ b/pkg/controllers/elasticsearch/cluster_control.go
@@ -104,5 +104,7 @@ func (e *defaultElasticsearchClusterControl) Sync(c *v1alpha1.ElasticsearchClust
 		return c.Status, err
 	}
 
+	e.recorder.Eventf(c, apiv1.EventTypeNormal, successSync, messageSuccessSync)
+
 	return c.Status, nil
 }


### PR DESCRIPTION
* Modify RBAC templates to allow navigator controller to create events for
  leader election and for sync messages.
* Add a SuccessSync message to the ElasticSearch control.
* Test for those events.

Fixes: #89 

**Release note**:
```release-note
NONE
```
