### PR TITLE
Revert "Only run Travis-CI tests for PRs and when master branch changes"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,3 @@ jobs:
           mkdir -p ~/.docker && echo "${DOCKER_AUTH_CONFIG}" > ~/.docker/config.json && chmod 600 ~/.docker/config.json;
           make docker_push IMAGE_TAGS="${TRAVIS_COMMIT} latest";
         fi
-
-# Only run tests when master branch changes or when a PR branch is updated.
-branches:
-  only:
-  - master


### PR DESCRIPTION
Reverts jetstack/navigator#77

It appears we're not always running the `/pr` test any more (see #101). I'm reverting this change as I've not had this problem before we added this section.

```release-note
NONE
```