### PR TITLE
Show minikube logs if it fails to start up

### DIFF
--- a/hack/install-e2e-dependencies.sh
+++ b/hack/install-e2e-dependencies.sh
@@ -2,6 +2,10 @@
 #
 # Install e2e test dependencies on Travis
 set -eux
+
+SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+source "${SCRIPT_DIR}/libe2e.sh"
+
 curl -Lo helm.tar.gz \
      https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz
 tar xvf helm.tar.gz

--- a/hack/install-e2e-dependencies.sh
+++ b/hack/install-e2e-dependencies.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+#
+# Install e2e test dependencies on Travis
 set -eux
 curl -Lo helm.tar.gz \
      https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz
@@ -23,3 +26,10 @@ sudo -E CHANGE_MINIKUBE_NONE_USER=true minikube start \
      --vm-driver=none \
      --kubernetes-version="$KUBERNETES_VERSION" \
      --extra-config=apiserver.Authorization.Mode=RBAC
+
+echo "Waiting up to 5 minutes for Kubernetes to be ready..."
+if ! retry TIMEOUT=300 kubectl get nodes; then
+    minikube logs
+    echo "ERROR: Timeout waiting for Minikube to be ready"
+    exit 1
+fi

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -5,9 +5,6 @@ SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 source "${SCRIPT_DIR}/libe2e.sh"
 
-echo "Waiting up to 10 minutes for Kubernetes to be ready..."
-retry TIMEOUT=600 kubectl get nodes
-
 echo "Installing helm..."
 cat <<EOF | kubectl apply -f -
 apiVersion: v1


### PR DESCRIPTION
E2E tests are sometimes failing because kubectl can't connect to the minikube api server.

Errors such as:

```
...
+kubectl get nodes

The connection to the server 127.0.0.1:8443 was refused - did you specify the right host or port?
...
```
https://travis-ci.org/jetstack/navigator/jobs/295839105#L640

[log.txt](https://github.com/jetstack/navigator/files/1453741/log.txt)


But there's no way of knowing why.

This PR will print the `minikube log` when this happens and wait 5 rather than 10 minutes before failing.

**Release note**:
```release-note
NONE
```
