### PR TITLE
Fix kube-dns RBAC issues

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -110,10 +110,12 @@ function test_elasticsearchcluster() {
 test_elasticsearchcluster
 
 function ignore_expected_errors() {
-    # Ignored failures to list navigator API objects when the controller starts
-    # before the API server has started and registered its self. E.g.
+    # Ignore the following error types:
     # E1103 14:58:06.819858       1 reflector.go:205] github.com/jetstack/navigator/pkg/client/informers/externalversions/factory.go:68: Failed to list *v1alpha1.Pilot: the server could not find the requested resource (get pilots.navigator.jetstack.io)
-    egrep --invert-match 'Failed to list \*v1alpha1\.\w+:\s+the server could not find the requested resource\s+\(get \w+\.navigator\.jetstack\.io\)$'
+    # E1108 14:18:37.610718       1 reflector.go:205] github.com/jetstack/navigator/pkg/client/informers/externalversions/factory.go:68: Failed to list *v1alpha1.Pilot: an error on the server ("Error: 'dial tcp 10.0.0.233:443: getsockopt: connection refused'\nTrying to reach: 'https://10.0.0.233:443/apis/navigator.jetstack.io/v1alpha1/pilots?resourceVersion=0'") has prevented the request from succeeding (get pilots.navigator.jetstack.io)
+    egrep --invert-match \
+          -e 'Failed to list \*v1alpha1\.\w+:\s+the server could not find the requested resource\s+\(get \w+\.navigator\.jetstack\.io\)$' \
+          -e 'Failed to list \*v1alpha1\.\w+:\s+an error on the server \([^)]+\) has prevented the request from succeeding\s+\(get \w+\.navigator\.jetstack\.io\)$'
 }
 
 function test_logged_errors() {

--- a/hack/install-e2e-dependencies.sh
+++ b/hack/install-e2e-dependencies.sh
@@ -37,3 +37,12 @@ if ! retry TIMEOUT=300 kubectl get nodes; then
     echo "ERROR: Timeout waiting for Minikube to be ready"
     exit 1
 fi
+
+# Fix kube-dns RBAC issues.
+# Allow kube-dns and other kube-system services full access to the API.
+# See:
+# * https://github.com/kubernetes/minikube/issues/1734
+# * https://github.com/kubernetes/minikube/issues/1722
+kubectl create clusterrolebinding cluster-admin:kube-system \
+        --clusterrole=cluster-admin \
+        --serviceaccount=kube-system:default

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -11,26 +11,6 @@ apiVersion: v1
 kind: List
 items:
 
-### Fix kube-dns RBAC issues ###
-# Create a ServiceAccount for kube-dns to use
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: kube-dns
-    namespace: kube-system
-- apiVersion: rbac.authorization.k8s.io/v1beta1
-  kind: ClusterRoleBinding
-  metadata:
-    name: system:kube-dns
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: system:kube-dns
-  subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: kube-system
-
 ### Tiller ###
 # Create a ServiceAccount for tiller to use
 - apiVersion: v1


### PR DESCRIPTION
Allow kube-dns and other kube-system services full access to the API.
See:
* https://github.com/kubernetes/minikube/issues/1734
* https://github.com/kubernetes/minikube/issues/1722

Fixes: #107 

**Release note**:
```release-note
NONE
```
