### PR TITLE
Allow the log level to be configured in the helm chart

### DIFF
--- a/contrib/charts/navigator/templates/apiserver.yaml
+++ b/contrib/charts/navigator/templates/apiserver.yaml
@@ -40,6 +40,7 @@ spec:
           - --requestheader-username-headers=X-Remote-User
           - --requestheader-group-headers=X-Remote-Group
           - --requestheader-extra-headers-prefix=X-Remote-Extra
+          - --v={{ .Values.apiserver.logLevel }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         - name: etcd

--- a/contrib/charts/navigator/templates/controller.yaml
+++ b/contrib/charts/navigator/templates/controller.yaml
@@ -38,7 +38,7 @@ spec:
           - --namespace={{ .Values.controller.namespace }}
           - --leader-election-namespace={{ .Values.controller.namespace }}
 {{- end }}
-          - --v=100
+          - --v={{ .Values.controller.logLevel }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/contrib/charts/navigator/values.yaml
+++ b/contrib/charts/navigator/values.yaml
@@ -17,7 +17,7 @@ apiserver:
     repository: jetstackexperimental/navigator-apiserver
     tag: latest
     pullPolicy: Always
-
+  logLevel: 100
 controller:
   ## Optional: namespace to watch for resources in. This can be used when RBAC
   ## restricts you to a single namespace.
@@ -28,7 +28,7 @@ controller:
     repository: jetstackexperimental/navigator-controller
     tag: latest
     pullPolicy: Always
-
+  logLevel: 100
 resources:
   requests:
     cpu: 50m

--- a/contrib/charts/navigator/values.yaml
+++ b/contrib/charts/navigator/values.yaml
@@ -17,7 +17,7 @@ apiserver:
     repository: jetstackexperimental/navigator-apiserver
     tag: latest
     pullPolicy: Always
-  logLevel: 100
+  logLevel: 2
 controller:
   ## Optional: namespace to watch for resources in. This can be used when RBAC
   ## restricts you to a single namespace.
@@ -28,7 +28,7 @@ controller:
     repository: jetstackexperimental/navigator-controller
     tag: latest
     pullPolicy: Always
-  logLevel: 100
+  logLevel: 2
 resources:
   requests:
     cpu: 50m

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -22,7 +22,9 @@ kube_delete_namespace_and_wait "${USER_NAMESPACE}"
 echo "Installing navigator..."
 helm install --wait --name "${RELEASE_NAME}" contrib/charts/navigator \
         --set apiserver.image.pullPolicy=Never \
-        --set controller.image.pullPolicy=Never
+        --set apiserver.logLevel=100 \
+        --set controller.image.pullPolicy=Never \
+        --set controller.logLevel=100
 
 # Wait for navigator API to be ready
 function navigator_ready() {

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -120,10 +120,15 @@ function ignore_expected_errors() {
 
 function test_logged_errors() {
     if kubectl logs deployments/nav-e2e-navigator-controller \
-            | egrep '^E' \
+            | egrep '^E[0-9]{4} ' \
             | ignore_expected_errors
     then
         fail_test "Unexpected errors in controller logs"
+    fi
+    if kubectl logs deployments/nav-e2e-navigator-controller \
+            | egrep '^E[0-9]{4} '
+    then
+        fail_test "Unexpected errors in apiserver logs"
     fi
 }
 

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -127,7 +127,7 @@ function test_logged_errors() {
     then
         fail_test "Unexpected errors in controller logs"
     fi
-    if kubectl logs deployments/nav-e2e-navigator-apiserver \
+    if kubectl logs -c apiserver -l app=navigator,component=apiserver \
             | egrep '^E[0-9]{4} '
     then
         fail_test "Unexpected errors in apiserver logs"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -127,7 +127,7 @@ function test_logged_errors() {
     then
         fail_test "Unexpected errors in controller logs"
     fi
-    if kubectl logs deployments/nav-e2e-navigator-controller \
+    if kubectl logs deployments/nav-e2e-navigator-apiserver \
             | egrep '^E[0-9]{4} '
     then
         fail_test "Unexpected errors in apiserver logs"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -111,7 +111,7 @@ function test_elasticsearchcluster() {
 
 test_elasticsearchcluster
 
-function ignore_expected_errors() {
+function ignore_expected_controller_errors() {
     # Ignore the following error types:
     # E1103 14:58:06.819858       1 reflector.go:205] github.com/jetstack/navigator/pkg/client/informers/externalversions/factory.go:68: Failed to list *v1alpha1.Pilot: the server could not find the requested resource (get pilots.navigator.jetstack.io)
     # E1108 14:18:37.610718       1 reflector.go:205] github.com/jetstack/navigator/pkg/client/informers/externalversions/factory.go:68: Failed to list *v1alpha1.Pilot: an error on the server ("Error: 'dial tcp 10.0.0.233:443: getsockopt: connection refused'\nTrying to reach: 'https://10.0.0.233:443/apis/navigator.jetstack.io/v1alpha1/pilots?resourceVersion=0'") has prevented the request from succeeding (get pilots.navigator.jetstack.io)
@@ -121,9 +121,9 @@ function ignore_expected_errors() {
 }
 
 function test_logged_errors() {
-    if kubectl logs deployments/nav-e2e-navigator-controller \
+    if kubectl logs -c controller -l app=navigator,component=controller \
             | egrep '^E[0-9]{4} ' \
-            | ignore_expected_errors
+            | ignore_expected_controller_errors
     then
         fail_test "Unexpected errors in controller logs"
     fi


### PR DESCRIPTION
* Adds a logLevel parameter for the apiserver and the controller deployments.
* Sets the logLevel to 100 by default
* Additional e2e test for unexpected apiserver errors.

**Release note**:
```release-note
NONE
```
