### PR TITLE
Update controller clusterrole to allow it to manage cassandraclusters 

### DIFF
--- a/contrib/charts/navigator/templates/rbac.yaml
+++ b/contrib/charts/navigator/templates/rbac.yaml
@@ -87,7 +87,7 @@ items:
     name: "{{ template "fullname" . }}:controller"
   rules:
   - apiGroups: ["navigator.jetstack.io"]
-    resources: ["elasticsearchclusters", "pilots"]
+    resources: ["elasticsearchclusters", "pilots", "cassandraclusters"]
     verbs:     ["get", "list", "watch", "update", "create", "delete"]
   - apiGroups: [""]
     resources: ["services", "configmaps", "serviceaccounts", "pods"]


### PR DESCRIPTION
* I also removed the `navigator:authenticated` clusterrole from prepare-e2e.sh because I don't understand why it's needed.

* Navigator controller is authenticated via serviceAccount `nav-e2e-navigator-controller`
* That service account is bound to ClusterRole `nav-e2e-navigator:controller` 

```
kubectl get clusterrolebindings nav-e2e-navigator:controller -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  creationTimestamp: 2017-11-09T12:11:31Z
  name: nav-e2e-navigator:controller
  resourceVersion: "1699"
  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/nav-e2e-navigator%3Acontroller
  uid: 1f79fa4b-c547-11e7-8aa2-52540064a5b1
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: nav-e2e-navigator:controller
subjects:
- kind: ServiceAccount
  name: nav-e2e-navigator-controller
  namespace: default

```

* ClusterRole `nav-e2e-navigator:controller` allows all verbs on all Navigator resources.

```
kubectl get clusterrole nav-e2e-navigator:controller -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  creationTimestamp: 2017-11-09T12:11:31Z
  name: nav-e2e-navigator:controller
  resourceVersion: "1694"
  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/nav-e2e-navigator%3Acontroller
  uid: 1f7462a7-c547-11e7-8aa2-52540064a5b1
rules:
- apiGroups:
  - navigator.jetstack.io
  resources:
  - elasticsearchclusters
  - pilots
  - cassandraclusters
  verbs:
  - get
  - list
  - watch
  - update
  - create
  - delete
...
```

Fixes: #110

**Release note**:
```release-note
NONE
```
