### PR TITLE
Remove unnecessary apiserver flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,6 @@ jobs:
       - make BUILD_TAG=latest build e2e-test
 
     - stage: test
-      env:
-      - KUBERNETES_VERSION=v1.7.0
-      before_script:
-      - ./hack/install-e2e-dependencies.sh
-      script:
-      - make BUILD_TAG=latest build e2e-test
-
-    - stage: test
       script:
       - make verify
 

--- a/contrib/charts/navigator/templates/apiserver.yaml
+++ b/contrib/charts/navigator/templates/apiserver.yaml
@@ -36,10 +36,6 @@ spec:
           args:
           - navigator-apiserver
           - --etcd-servers=http://localhost:2379
-          - --requestheader-client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          - --requestheader-username-headers=X-Remote-User
-          - --requestheader-group-headers=X-Remote-Group
-          - --requestheader-extra-headers-prefix=X-Remote-Extra
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         - name: etcd

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -60,6 +60,8 @@ if ! retry navigator_ready; then
     kubectl get pods --all-namespaces
     kubectl describe deploy
     kubectl describe pod
+    kubectl logs -c apiserver -l app=navigator,component=apiserver
+    kubectl logs -c controller -l app=navigator,component=controller
     echo "ERROR: Timeout waiting for Navigator API"
     exit 1
 fi

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -32,33 +32,6 @@ items:
     kind: ServiceAccount
     name: tiller
     namespace: kube-system
-### Generic ###
-# Create a ClusterRole to work with ElasticsearchCluster resources
-- apiVersion: rbac.authorization.k8s.io/v1beta1
-  kind: ClusterRole
-  metadata:
-    name: navigator:authenticated
-  # this rule defined on the role for specifically the
-  # namespace-lifecycle admission-controller
-  rules:
-  - apiGroups: ["navigator.jetstack.io"]
-    resources: ["elasticsearchclusters", "pilots"]
-    verbs:     ["get", "list", "watch", "create", "update", "delete"]
-- apiVersion: rbac.authorization.k8s.io/v1beta1
-  kind: ClusterRoleBinding
-  metadata:
-    name: "navigator:authenticated"
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: navigator:authenticated
-  subjects:
-  - kind: Group
-    name: system:authenticated
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: system:unauthenticated
-    apiGroup: rbac.authorization.k8s.io
 EOF
 helm init --service-account=tiller
 


### PR DESCRIPTION
These were somehow preventing the navigator API server from seeing the user that
made the original request to the k8s API server.

Fixes: #110 

**Release note**:
```release-note
NONE
```
