### PR TITLE
WIP: Testing RBAC with Kubernetes 1.7

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -62,6 +62,8 @@ if ! retry navigator_ready; then
     kubectl get pods --all-namespaces
     kubectl describe deploy
     kubectl describe pod
+    kubectl logs -c apiserver -l app=navigator,component=apiserver
+    kubectl logs -c controller -l app=navigator,component=controller
     echo "ERROR: Timeout waiting for Navigator API"
     exit 1
 fi

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -32,33 +32,6 @@ items:
     kind: ServiceAccount
     name: tiller
     namespace: kube-system
-### Generic ###
-# Create a ClusterRole to work with ElasticsearchCluster resources
-- apiVersion: rbac.authorization.k8s.io/v1beta1
-  kind: ClusterRole
-  metadata:
-    name: navigator:authenticated
-  # this rule defined on the role for specifically the
-  # namespace-lifecycle admission-controller
-  rules:
-  - apiGroups: ["navigator.jetstack.io"]
-    resources: ["elasticsearchclusters", "pilots"]
-    verbs:     ["get", "list", "watch", "create", "update", "delete"]
-- apiVersion: rbac.authorization.k8s.io/v1beta1
-  kind: ClusterRoleBinding
-  metadata:
-    name: "navigator:authenticated"
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: navigator:authenticated
-  subjects:
-  - kind: Group
-    name: system:authenticated
-    apiGroup: rbac.authorization.k8s.io
-  - kind: Group
-    name: system:unauthenticated
-    apiGroup: rbac.authorization.k8s.io
 EOF
 helm init --service-account=tiller
 


### PR DESCRIPTION
We want to see if there are RBAC problems with Kubernetes 1.7.

* Kube 1.7 e2e tests should pass
* Kube 1.8 e2e tests should fail because of overriding `--requestheader-...` arguments 

**Release note**:
```release-note
NONE
```
