### PR TITLE
Correct handling of service updates

### DIFF
--- a/contrib/charts/cassandra/templates/cassandracluster.yaml
+++ b/contrib/charts/cassandra/templates/cassandracluster.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  cqlPort: {{ .Values.cqlPort }}
   sysctl:
   - vm.max_map_count=0
   nodePools:

--- a/contrib/charts/cassandra/values.yaml
+++ b/contrib/charts/cassandra/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 3
+cqlPort: 9042
 image:
   repository: gcr.io/google-samples/cassandra
   tag: v12

--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -3,6 +3,7 @@ kind: CassandraCluster
 metadata:
   name: demo
 spec:
+  cqlPort: 9042
   sysctl:
   - vm.max_map_count=0
   nodePools:

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -160,6 +160,20 @@ function test_cassandracluster() {
             --namespace "${USER_NAMESPACE}" \
             "statefulset/cass-${CHART_NAME}-cassandra-ringnodes"
 
+    # Change the CQL port
+    helm --debug upgrade \
+         "${CHART_NAME}" \
+         contrib/charts/cassandra \
+         --set cqlPort=9043
+
+    # Wait 60s for cassandra CQL port to change
+    if ! retry TIMEOUT=60 kube_service_responding \
+         "${USER_NAMESPACE}" \
+         "cass-${CHART_NAME}-cassandra" \
+         9043; then
+        fail_test "Navigator controller failed to update cassandracluster service"
+    fi
+
     # Increment the replica count
     helm --debug upgrade \
          "${CHART_NAME}" \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -198,7 +198,9 @@ function ignore_expected_controller_errors() {
     # E1108 14:18:37.610718       1 reflector.go:205] github.com/jetstack/navigator/pkg/client/informers/externalversions/factory.go:68: Failed to list *v1alpha1.Pilot: an error on the server ("Error: 'dial tcp 10.0.0.233:443: getsockopt: connection refused'\nTrying to reach: 'https://10.0.0.233:443/apis/navigator.jetstack.io/v1alpha1/pilots?resourceVersion=0'") has prevented the request from succeeding (get pilots.navigator.jetstack.io)
     egrep --invert-match \
           -e 'Failed to list \*v1alpha1\.\w+:\s+the server could not find the requested resource\s+\(get \w+\.navigator\.jetstack\.io\)$' \
-          -e 'Failed to list \*v1alpha1\.\w+:\s+an error on the server \([^)]+\) has prevented the request from succeeding\s+\(get \w+\.navigator\.jetstack\.io\)$'
+          -e 'Failed to list \*v1alpha1\.\w+:\s+an error on the server \([^)]+\) has prevented the request from succeeding\s+\(get \w+\.navigator\.jetstack\.io\)$' \
+          -e 'Failed to update lock: etcdserver: request timed out' \
+          -e 'Failed to update lock: Operation cannot be fulfilled on endpoints "navigator-controller"'
 }
 
 function test_logged_errors() {

--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -65,3 +65,13 @@ function kube_event_exists() {
     fi
     return 1
 }
+
+function stdout_equals() {
+    local expected="${1}"
+    shift
+    local actual=$("${@}")
+    if [[ "${expected}" == "${actual}" ]]; then
+        return 0
+    fi
+    return 1
+}

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -26,7 +26,7 @@ type CassandraClusterSpec struct {
 	Sysctl    []string
 	NodePools []CassandraClusterNodePool
 	Image     CassandraImage
-	CqlPort   int64
+	CqlPort   int32
 }
 
 type CassandraImage struct {

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -26,6 +26,7 @@ type CassandraClusterSpec struct {
 	Sysctl    []string
 	NodePools []CassandraClusterNodePool
 	Image     CassandraImage
+	CqlPort   int64
 }
 
 type CassandraImage struct {

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -26,6 +26,7 @@ type CassandraClusterSpec struct {
 	Sysctl    []string                   `json:"sysctl"`
 	NodePools []CassandraClusterNodePool `json:"nodePools"`
 	Image     CassandraImage             `json:"image"`
+	CqlPort   int64                      `json:"cqlPort"`
 }
 
 type CassandraImage struct {

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -26,7 +26,7 @@ type CassandraClusterSpec struct {
 	Sysctl    []string                   `json:"sysctl"`
 	NodePools []CassandraClusterNodePool `json:"nodePools"`
 	Image     CassandraImage             `json:"image"`
-	CqlPort   int64                      `json:"cqlPort"`
+	CqlPort   int32                      `json:"cqlPort"`
 }
 
 type CassandraImage struct {

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -187,6 +187,7 @@ func autoConvert_v1alpha1_CassandraClusterSpec_To_navigator_CassandraClusterSpec
 	if err := Convert_v1alpha1_CassandraImage_To_navigator_CassandraImage(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
+	out.CqlPort = in.CqlPort
 	return nil
 }
 
@@ -201,6 +202,7 @@ func autoConvert_navigator_CassandraClusterSpec_To_v1alpha1_CassandraClusterSpec
 	if err := Convert_navigator_CassandraImage_To_v1alpha1_CassandraImage(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
+	out.CqlPort = in.CqlPort
 	return nil
 }
 

--- a/pkg/controllers/cassandra/service/control.go
+++ b/pkg/controllers/cassandra/service/control.go
@@ -54,6 +54,7 @@ func (e *defaultCassandraClusterServiceControl) Sync(cluster *v1alpha1.Cassandra
 			svc.Namespace, svc.Name, ownerRef, cluster.Namespace, cluster.Name,
 		)
 	}
-	_, err = client.Update(UpdateServiceForCluster(cluster, existingSvc))
+	updatedService := updateServiceForCluster(cluster, existingSvc)
+	_, err = client.Update(updatedService)
 	return err
 }

--- a/pkg/controllers/cassandra/service/control.go
+++ b/pkg/controllers/cassandra/service/control.go
@@ -54,6 +54,6 @@ func (e *defaultCassandraClusterServiceControl) Sync(cluster *v1alpha1.Cassandra
 			svc.Namespace, svc.Name, ownerRef, cluster.Namespace, cluster.Name,
 		)
 	}
-	_, err = client.Update(svc)
+	_, err = client.Update(UpdateServiceForCluster(cluster, existingSvc))
 	return err
 }

--- a/pkg/controllers/cassandra/service/resource.go
+++ b/pkg/controllers/cassandra/service/resource.go
@@ -29,7 +29,7 @@ func UpdateServiceForCluster(
 	service.Spec.Ports = []apiv1.ServicePort{
 		{
 			Name:       "transport",
-			Port:       int32(9042),
+			Port:       cluster.Spec.CqlPort,
 			TargetPort: intstr.FromInt(9042),
 		},
 	}

--- a/pkg/controllers/cassandra/service/resource.go
+++ b/pkg/controllers/cassandra/service/resource.go
@@ -11,25 +11,28 @@ import (
 func ServiceForCluster(
 	cluster *v1alpha1.CassandraCluster,
 ) *apiv1.Service {
-	svc := apiv1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            util.ResourceBaseName(cluster),
-			Namespace:       cluster.Namespace,
-			Labels:          util.ClusterLabels(cluster),
-			Annotations:     make(map[string]string),
-			OwnerReferences: []metav1.OwnerReference{util.NewControllerRef(cluster)},
-		},
-		Spec: apiv1.ServiceSpec{
-			Type: apiv1.ServiceTypeClusterIP,
-			Ports: []apiv1.ServicePort{
-				{
-					Name:       "transport",
-					Port:       int32(9042),
-					TargetPort: intstr.FromInt(9042),
-				},
-			},
-			Selector: util.NodePoolLabels(cluster, ""),
+	return UpdateServiceForCluster(cluster, &apiv1.Service{})
+}
+
+func UpdateServiceForCluster(
+	cluster *v1alpha1.CassandraCluster,
+	service *apiv1.Service,
+) *apiv1.Service {
+	service = service.DeepCopy()
+	service.SetName(util.ResourceBaseName(cluster))
+	service.SetNamespace(cluster.Namespace)
+	service.SetLabels(util.ClusterLabels(cluster))
+	service.SetOwnerReferences([]metav1.OwnerReference{
+		util.NewControllerRef(cluster),
+	})
+	service.Spec.Type = apiv1.ServiceTypeClusterIP
+	service.Spec.Ports = []apiv1.ServicePort{
+		{
+			Name:       "transport",
+			Port:       int32(9042),
+			TargetPort: intstr.FromInt(9042),
 		},
 	}
-	return &svc
+	service.Spec.Selector = util.NodePoolLabels(cluster, "")
+	return service
 }

--- a/pkg/controllers/cassandra/service/resource.go
+++ b/pkg/controllers/cassandra/service/resource.go
@@ -11,10 +11,10 @@ import (
 func ServiceForCluster(
 	cluster *v1alpha1.CassandraCluster,
 ) *apiv1.Service {
-	return UpdateServiceForCluster(cluster, &apiv1.Service{})
+	return updateServiceForCluster(cluster, &apiv1.Service{})
 }
 
-func UpdateServiceForCluster(
+func updateServiceForCluster(
 	cluster *v1alpha1.CassandraCluster,
 	service *apiv1.Service,
 ) *apiv1.Service {

--- a/pkg/controllers/cassandra/testing/testing.go
+++ b/pkg/controllers/cassandra/testing/testing.go
@@ -22,6 +22,7 @@ import (
 func ClusterForTest() *v1alpha1.CassandraCluster {
 	c := &v1alpha1.CassandraCluster{
 		Spec: v1alpha1.CassandraClusterSpec{
+			CqlPort: 9042,
 			NodePools: []v1alpha1.CassandraClusterNodePool{
 				v1alpha1.CassandraClusterNodePool{
 					Name:     "RingNodes",


### PR DESCRIPTION
The service controller was attempting and failing to update a service resource using a brand new struct, rather than taking the existing struct (which may have been modified by admission controllers, service controller etc) and modifying only the fields of interest to the cassandra database.

This fixes that and adds an e2e test which verifies that the service can be modified.

I also test  that the statefulsets can be scaled since that was how I originally encountered this issue.

Fixes: #124 

**Release note**:
```release-note
NONE
```
