### PR TITLE
Print etcd logs in e2e test failures

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -164,6 +164,7 @@ if [[ "${FAILURE_COUNT}" -gt 0 ]]; then
     kubectl describe apiservice
     kubectl logs -c apiserver -l app=navigator,component=apiserver
     kubectl logs -c controller -l app=navigator,component=controller
+    kubectl logs -c etcd -l app=navigator,component=apiserver
 fi
 
 exit $FAILURE_COUNT


### PR DESCRIPTION
**What this PR does / why we need it**:

In an attempt to debug etcd timeouts, print etcd logs on test failures

**Release note**:
```release-note
NONE
```

/assign