### PR TITLE
ReadinessProbes and LivenessProbes

### DIFF
--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -66,6 +66,18 @@ function kube_event_exists() {
     return 1
 }
 
+function kube_simulate_unresponsive_process() {
+    local namespace=$1
+    local pod=$2
+    local container=$3
+    # Send STOP signal to all processes in the root process group
+    # https://unix.stackexchange.com/a/149756
+    kubectl \
+        --namespace="${namespace}" \
+        exec "${pod}" --container="${container}" -- \
+        kill -SIGSTOP --  -1
+}
+
 function stdout_equals() {
     local expected="${1}"
     shift

--- a/pkg/controllers/cassandra/service/seedprovider/resource.go
+++ b/pkg/controllers/cassandra/service/seedprovider/resource.go
@@ -7,6 +7,10 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 )
 
+const (
+	TolerateUnreadyEndpointsAnnotationKey = "service.alpha.kubernetes.io/tolerate-unready-endpoints"
+)
+
 func ServiceForCluster(
 	cluster *v1alpha1.CassandraCluster,
 ) *apiv1.Service {
@@ -30,5 +34,19 @@ func updateServiceForCluster(
 			Port: 65535,
 		},
 	}
+	// This ensures that DNS names are published regardless of whether the
+	// Cassandra pod ReadinessProbes (listening on their CQL port).
+	// It won't handle CQL connections until it has successfully connected and
+	// negotiated with a seed host
+	service.Spec.PublishNotReadyAddresses = true
+	// XXX: This annotation is only necessary for Kubernetes <=1.7, which do not
+	// pay attention to the field above.
+	// Remove it when we no longer support those versions.
+	annotations := service.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[TolerateUnreadyEndpointsAnnotationKey] = "true"
+	service.SetAnnotations(annotations)
 	return service
 }


### PR DESCRIPTION
ReadinessProbes and LivenessProbes

* Added ReadinessProbe that calls /ready-probe.sh
* Added a LivenessProbe that also calls /ready-probe.sh, but with a delay, to allow the database to initialise and connect to its peers.
* Added an E2E test for readiness probe, that stops the processes inside the first cassandra pod and tests that the CQL service is still reachable, i.e. the readiness probe has failed and the service is no longer routing to that pod.
* Use cqlsh to better test that the cassandra CQL port is responding. Netcat only tested that a TCP connection could be established, which also works when the listening process has been stopped.
* Set the `PublishNotReadyAddresses` field on the headless service so that node hostnames names get published regardless of the ReadinessProbe. This allows joining nodes to find peers regardless of whether they are ready.
* Also set the "tolerate-unready-endpoints" annotation for backwards compatibility with Kubernetes <= 1.7

Fixes: #136

**Release note**:
```release-note
NONE
```