### PR TITLE
Print `kubectl cluster-info dump` when E2E tests are complete.

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -163,18 +163,8 @@ function test_logged_errors() {
 
 test_logged_errors
 
-if [[ "${FAILURE_COUNT}" -gt 0 ]]; then
-    kubectl get po -o yaml
-    kubectl describe po
-    kubectl get svc -o yaml
-    kubectl describe svc
-    kubectl get apiservice -o yaml
-    kubectl describe apiservice
-    kubectl logs -c apiserver -l app=navigator,component=apiserver
-    kubectl logs -c controller -l app=navigator,component=controller
-    kubectl logs -c etcd -l app=navigator,component=apiserver
-    kubectl logs --namespace "${USER_NAMESPACE}" "es-test-mixed-0" || true
-    kubectl describe pilots --all-namespaces || true
-fi
+kubectl api-versions
+kubectl get apiservice -o yaml
+kubectl cluster-info dump --all-namespaces || true
 
 exit $FAILURE_COUNT


### PR DESCRIPTION
`kubectl cluster-info dump --all-namespaces` shows:
 * all kubelet nodes
 * events, replicationcontroller, svc, daemonsets, deployments, replicasets, pods,  in all namespaces
 * logs from all pods.

So:
* I've replaced a bunch of the existing debug commands with this single command and
* print the debug info on test failure *and* success, because I've found the information useful when trying figure out how e.g. Cassandra logs look look in the normal case.

Fixes: #138


**Release note**:
```release-note
NONE
```
