### PR TITLE
Delete Elasticsearch test namespace after e2e run

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -134,6 +134,9 @@ function test_elasticsearchcluster() {
             --all; then
         fail_test "Failed to delete elasticsearchcluster"
     fi
+    if ! kube_delete_namespace_and_wait "${USER_NAMESPACE}"; then
+        fail_test "Failed to delete test namespace"
+    fi
 }
 
 test_elasticsearchcluster

--- a/pkg/pilot/genericpilot/controller.go
+++ b/pkg/pilot/genericpilot/controller.go
@@ -72,13 +72,16 @@ func (g *GenericPilot) sync(key string) (err error) {
 	pilot, err := g.pilotLister.Pilots(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
 		glog.Infof("Pilot %q has been deleted", key)
-		if !g.isThisPilot(name, namespace) || g.cachedThisPilot == nil {
+		if !g.isThisPilot(name, namespace) {
+			return nil
+		}
+		var thisPilot *v1alpha1.Pilot
+		thisPilot, err = g.ThisPilot()
+		if err != nil {
 			return nil
 		}
 		glog.Infof("Using cached pilot resource for %q", key)
-		pilot = g.cachedThisPilot
-		// set err to nil so the following block does not return err
-		err = nil
+		pilot = thisPilot
 	}
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to retrieve Pilot %v from store: %v", key, err))

--- a/pkg/pilot/genericpilot/genericpilot.go
+++ b/pkg/pilot/genericpilot/genericpilot.go
@@ -49,6 +49,13 @@ type GenericPilot struct {
 	lock sync.Mutex
 	// scheduledWorkQueue is used to periodically re-sync 'this' Pilot resource.
 	scheduledWorkQueue scheduler.ScheduledWorkQueue
+	// cachedThisPilot is a reference to a Pilot resource for 'this' Pilot.
+	// It may be out of date, and it should *never* be manipulated.
+	// This is especially useful for circumstances where the Pilot resource is
+	// no longer available, either due to a network outage, the namespace
+	// containing the Pilot resource being deleted, or any other circumstance
+	// leading to the Pilot lister to not contain a reference to 'this' pilot.
+	cachedThisPilot *v1alpha1.Pilot
 }
 
 // only run one worker to prevent threading issues when dealing with processes

--- a/pkg/pilot/genericpilot/util.go
+++ b/pkg/pilot/genericpilot/util.go
@@ -12,7 +12,11 @@ import (
 // IsThisPilot will return true if 'pilot' corresponds to the Pilot resource
 // for this pilot.
 func (g *GenericPilot) IsThisPilot(pilot *v1alpha1.Pilot) bool {
-	return pilot.Name == g.Options.PilotName && pilot.Namespace == g.Options.PilotNamespace
+	return g.isThisPilot(pilot.Name, pilot.Namespace)
+}
+
+func (g *GenericPilot) isThisPilot(name, namespace string) bool {
+	return name == g.Options.PilotName && namespace == g.Options.PilotNamespace
 }
 
 func (g *GenericPilot) IsPeer(pilot *v1alpha1.Pilot) (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR cleans up the namespace used during tests after the test has run. Previously, this would not happen due errors when genericpilot attempts to exit after it's Pilot resource has been deleted.

In order to work around this, I have added a new cachedThisPilot field to GenericPilot, which is used in favour of the 'up to date' Pilot resource from the API server. This allows GenericPilot to continue operating in the event of it's own Pilot being deleted, or in the case of some other issue that may arise.

Moving forward, we need to ensure that *all* our e2e tests clean up unused resources upon completion, as we cannot infinitely increase the size of our build VMs just so we can keep logs hanging around. If we need logs from pods, we should retrieve them as part of the tear-down for that particular test suite.

**Release note**:
```release-note
NONE
```
