### PR TITLE
Remove references to minikube in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 - docker
 
 script:
-- make docker_build
+- make build docker_build
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
     mkdir -p ~/.docker && echo "${DOCKER_AUTH_CONFIG}" > ~/.docker/config.json && chmod 600 ~/.docker/config.json;
     make docker_push IMAGE_TAGS="${TRAVIS_COMMIT} latest";

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ verify: .hack_verify go_verify
 DOCKER_BUILD_TARGETS = $(addprefix docker_build_, $(CMDS))
 $(DOCKER_BUILD_TARGETS):
 	$(eval DOCKER_BUILD_CMD := $(subst docker_build_,,$@))
-	eval $$(minikube docker-env --profile $$HOSTNAME --shell sh); \
 	docker build -t $(REGISTRY)/$(IMAGE_NAME)-$(DOCKER_BUILD_CMD):$(BUILD_TAG) -f Dockerfile.$(DOCKER_BUILD_CMD) .
 docker_build: $(DOCKER_BUILD_TARGETS)
 
@@ -70,7 +69,6 @@ $(DOCKER_PUSH_TARGETS):
 	$(eval DOCKER_PUSH_CMD := $(subst docker_push_,,$@))
 	set -e; \
 		for tag in $(IMAGE_TAGS); do \
-		eval $$(minikube docker-env --profile $$HOSTNAME --shell sh); \
 		docker tag $(REGISTRY)/$(IMAGE_NAME)-$(DOCKER_PUSH_CMD):$(BUILD_TAG) $(REGISTRY)/$(IMAGE_NAME)-$(DOCKER_PUSH_CMD):$${tag} ; \
 		docker push $(REGISTRY)/$(IMAGE_NAME)-$(DOCKER_PUSH_CMD):$${tag}; \
 	done


### PR DESCRIPTION
**What this PR does / why we need it**:

Since #144 has merged, we no longer reference minikube within navigator. Our builds on travis are now failing, as Travis does not have (nor need) minikube. This PR fixes up the Makefile to reflect these latest changes.

**Release note**:
```release-note
NONE
```
