### PR TITLE
Create Cassandra Pilot resources

### DIFF
--- a/pkg/controllers/cassandra/pilot/pilot.go
+++ b/pkg/controllers/cassandra/pilot/pilot.go
@@ -1,0 +1,182 @@
+package pilot
+
+import (
+	"fmt"
+	"hash/fnv"
+	"reflect"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	navigator "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	navlisters "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+	hashutil "github.com/jetstack/navigator/pkg/util/hash"
+	"k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	appslisters "k8s.io/client-go/listers/apps/v1beta1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	HashAnnotationKey = "navigator.jetstack.io/cassandra-pilot-hash"
+)
+
+type Interface interface {
+	Sync(*v1alpha1.CassandraCluster) error
+}
+
+type pilotControl struct {
+	naviClient   navigator.Interface
+	pilots       navlisters.PilotLister
+	pods         corelisters.PodLister
+	statefulSets appslisters.StatefulSetLister
+	recorder     record.EventRecorder
+}
+
+var _ Interface = &pilotControl{}
+
+func NewControl(
+	naviClient navigator.Interface,
+	pilots navlisters.PilotLister,
+	pods corelisters.PodLister,
+	statefulSets appslisters.StatefulSetLister,
+	recorder record.EventRecorder,
+) *pilotControl {
+	return &pilotControl{
+		naviClient:   naviClient,
+		pilots:       pilots,
+		pods:         pods,
+		statefulSets: statefulSets,
+		recorder:     recorder,
+	}
+
+}
+
+func (c *pilotControl) clusterPods(cluster *v1alpha1.CassandraCluster) ([]*v1.Pod, error) {
+	var clusterPods []*v1.Pod
+	allPods, err := c.pods.Pods(cluster.Namespace).List(labels.Everything())
+	if err != nil {
+		return clusterPods, err
+	}
+	for _, pod := range allPods {
+		podControlledByCluster, err := controllers.PodControlledByCluster(
+			cluster,
+			pod,
+			c.statefulSets,
+		)
+		if err != nil {
+			return clusterPods, err
+		}
+		if !podControlledByCluster {
+			continue
+		}
+		clusterPods = append(clusterPods, pod)
+	}
+	return clusterPods, nil
+}
+
+func (c *pilotControl) createOrUpdatePilot(cluster *v1alpha1.CassandraCluster, pod *v1.Pod) error {
+	desiredPilot := PilotForCluster(cluster, pod)
+	client := c.naviClient.NavigatorV1alpha1().Pilots(desiredPilot.GetNamespace())
+	lister := c.pilots.Pilots(desiredPilot.GetNamespace())
+	existingPilot, err := lister.Get(desiredPilot.GetName())
+	if k8sErrors.IsNotFound(err) {
+		_, err = client.Create(desiredPilot)
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	err = util.OwnerCheck(existingPilot, cluster)
+	if err != nil {
+		return err
+	}
+	existingPilot = existingPilot.DeepCopy()
+	existingPilot.Status = v1alpha1.PilotStatus{}
+	desiredPilot = existingPilot.DeepCopy()
+	desiredPilot = updatePilotForCluster(cluster, pod, desiredPilot)
+	if !reflect.DeepEqual(desiredPilot, existingPilot) {
+		_, err = client.Update(desiredPilot)
+	}
+	return err
+}
+
+func (c *pilotControl) syncPilots(cluster *v1alpha1.CassandraCluster) error {
+	pods, err := c.clusterPods(cluster)
+	if err != nil {
+		return err
+	}
+	for _, pod := range pods {
+		err = c.createOrUpdatePilot(cluster, pod)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func (c *pilotControl) Sync(cluster *v1alpha1.CassandraCluster) error {
+	err := c.syncPilots(cluster)
+	if err != nil {
+		return err
+	}
+	// TODO: Housekeeping. Remove pilots that don't have a corresponding pod.
+	return nil
+}
+
+func PilotForCluster(cluster *v1alpha1.CassandraCluster, pod *v1.Pod) *v1alpha1.Pilot {
+	pilot := &v1alpha1.Pilot{}
+	pilot.SetOwnerReferences(
+		[]metav1.OwnerReference{
+			util.NewControllerRef(cluster),
+		},
+	)
+	return updatePilotForCluster(cluster, pod, pilot)
+}
+
+func updatePilotForCluster(
+	cluster *v1alpha1.CassandraCluster,
+	pod *v1.Pod,
+	pilot *v1alpha1.Pilot,
+) *v1alpha1.Pilot {
+	pilot.SetName(pod.GetName())
+	pilot.SetNamespace(cluster.GetNamespace())
+	labels := pilot.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	for key, val := range util.ClusterLabels(cluster) {
+		labels[key] = val
+	}
+	pilot.SetLabels(labels)
+	ComputeHashAndUpdateAnnotation(pilot)
+	return pilot
+}
+
+func ComputeHash(p *v1alpha1.Pilot) uint32 {
+	hashVar := []interface{}{
+		p.Spec,
+		p.ObjectMeta,
+		p.Labels,
+	}
+	hasher := fnv.New32()
+	hashutil.DeepHashObject(hasher, hashVar)
+	return hasher.Sum32()
+}
+
+func UpdateHashAnnotation(p *v1alpha1.Pilot, hash uint32) {
+	annotations := p.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[HashAnnotationKey] = fmt.Sprintf("%d", hash)
+	p.SetAnnotations(annotations)
+}
+
+func ComputeHashAndUpdateAnnotation(p *v1alpha1.Pilot) {
+	hash := ComputeHash(p)
+	UpdateHashAnnotation(p, hash)
+}

--- a/pkg/controllers/cassandra/pilot/pilot_test.go
+++ b/pkg/controllers/cassandra/pilot/pilot_test.go
@@ -1,0 +1,144 @@
+package pilot_test
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/pilot"
+	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func clusterPod(cluster *v1alpha1.CassandraCluster, name string) *v1.Pod {
+	pod := &v1.Pod{}
+	pod.SetName(name)
+	pod.SetNamespace(cluster.GetNamespace())
+	pod.SetOwnerReferences(
+		[]metav1.OwnerReference{
+			util.NewControllerRef(cluster),
+		},
+	)
+	return pod
+}
+
+func nonClusterPod(cluster *v1alpha1.CassandraCluster, name string) *v1.Pod {
+	p := clusterPod(cluster, name)
+	p.SetOwnerReferences([]metav1.OwnerReference{})
+	return p
+}
+
+func TestPilotSync(t *testing.T) {
+	t.Run(
+		"each cluster pod gets a pilot",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			f.AddObjectK(clusterPod(f.Cluster, "foo"))
+			f.AddObjectK(clusterPod(f.Cluster, "bar"))
+			f.Run()
+			f.AssertPilotsLength(2)
+		},
+	)
+	t.Run(
+		"non-cluster pods are ignored",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			f.AddObjectK(clusterPod(f.Cluster, "foo"))
+			f.AddObjectK(nonClusterPod(f.Cluster, "bar"))
+			f.Run()
+			f.AssertPilotsLength(1)
+		},
+	)
+	t.Run(
+		"pilot exists",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			pod := clusterPod(f.Cluster, "foo")
+			pilot := pilot.PilotForCluster(f.Cluster, pod)
+			f.AddObjectK(pod)
+			f.AddObjectN(pilot)
+			f.Run()
+			f.AssertPilotsLength(1)
+		},
+	)
+	t.Run(
+		"foreign owned pilot",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			pod := clusterPod(f.Cluster, "foo")
+			pilot := pilot.PilotForCluster(f.Cluster, pod)
+			pilot.SetOwnerReferences([]metav1.OwnerReference{})
+			f.AddObjectK(pod)
+			f.AddObjectN(pilot)
+			f.RunExpectError()
+			f.AssertPilotsLength(1)
+		},
+	)
+	t.Run(
+		"pilot sync when hash changes",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			pod := clusterPod(f.Cluster, "foo")
+			unsyncedPilot := pilot.PilotForCluster(f.Cluster, pod)
+			pilot.UpdateHashAnnotation(unsyncedPilot, 0)
+			f.AddObjectK(pod)
+			f.AddObjectN(unsyncedPilot)
+			f.Run()
+			f.AssertPilotsLength(1)
+			updatedPilot := f.Pilots().Items[0]
+			updatedPilotAnnotations := updatedPilot.GetAnnotations()
+			hash, ok := updatedPilotAnnotations[pilot.HashAnnotationKey]
+			if !ok {
+				t.Log(updatedPilotAnnotations)
+				t.Error("pilot hash annotation not found")
+			}
+			if hash == "0" {
+				t.Log(updatedPilot)
+				t.Error("Pilot was not updated")
+			}
+		},
+	)
+	t.Run(
+		"pilot no sync if hash matches",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			pod := clusterPod(f.Cluster, "foo")
+			// Remove the labels
+			unsyncedPilot := pilot.PilotForCluster(f.Cluster, pod)
+			unsyncedPilot.SetLabels(map[string]string{})
+			pilot.ComputeHashAndUpdateAnnotation(unsyncedPilot)
+			f.AddObjectK(pod)
+			f.AddObjectN(unsyncedPilot)
+			f.Run()
+			f.AssertPilotsLength(1)
+			updatedPilot := f.Pilots().Items[0]
+			updatedLabels := updatedPilot.GetLabels()
+			if len(updatedLabels) == 0 {
+				t.Log(updatedPilot)
+				t.Error("pilot was not updated")
+			}
+		},
+	)
+	t.Run(
+		"don't clobber custom labels",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			pod := clusterPod(f.Cluster, "foo")
+			// Remove the labels
+			unsyncedPilot := pilot.PilotForCluster(f.Cluster, pod)
+			unsyncedPilot.Labels["foo"] = "bar"
+			f.AddObjectK(pod)
+			f.AddObjectN(unsyncedPilot)
+			f.Run()
+			f.AssertPilotsLength(1)
+			updatedPilot := f.Pilots().Items[0]
+			updatedLabels := updatedPilot.GetLabels()
+			if updatedLabels["foo"] != "bar" {
+				t.Log(updatedLabels)
+				t.Error("custom labels were altered")
+			}
+		},
+	)
+}

--- a/pkg/controllers/cassandra/service/util/util.go
+++ b/pkg/controllers/cassandra/service/util/util.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"fmt"
-
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
@@ -46,13 +44,9 @@ func SyncService(
 	if err != nil {
 		return err
 	}
-	if !metav1.IsControlledBy(existingSvc, cluster) {
-		ownerRef := metav1.GetControllerOf(existingSvc)
-		return fmt.Errorf(
-			"A service with name '%s/%s' already exists, "+
-				"but it is controlled by '%v', not '%s/%s'.",
-			svc.Namespace, svc.Name, ownerRef, cluster.Namespace, cluster.Name,
-		)
+	err = util.OwnerCheck(existingSvc, cluster)
+	if err != nil {
+		return err
 	}
 	updatedService := updateService(cluster, existingSvc)
 	_, err = client.Update(updatedService)

--- a/pkg/controllers/cassandra/util/util.go
+++ b/pkg/controllers/cassandra/util/util.go
@@ -77,3 +77,20 @@ func NodePoolLabels(
 func Int32Ptr(i int32) *int32 {
 	return &i
 }
+
+func OwnerCheck(
+	obj metav1.Object,
+	owner metav1.Object,
+) error {
+	if !metav1.IsControlledBy(obj, owner) {
+		ownerRef := metav1.GetControllerOf(obj)
+		return fmt.Errorf(
+			"'%s/%s' is foreign owned: "+
+				"it is owned by '%v', not '%s/%s'.",
+			obj.GetNamespace(), obj.GetName(),
+			ownerRef,
+			owner.GetNamespace(), owner.GetName(),
+		)
+	}
+	return nil
+}

--- a/pkg/controllers/elasticsearch/nodepool/controller.go
+++ b/pkg/controllers/elasticsearch/nodepool/controller.go
@@ -19,6 +19,7 @@ import (
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
 	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
 	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
 )
 
@@ -87,7 +88,7 @@ func (e *statefulControl) syncNodePool(c *v1alpha1.ElasticsearchCluster, np *v1a
 	// if multiple exist, exit with an error
 	// if one exists:
 	//		- generate the expected StatefulSet manifest
-	// 		- compare the expected hashes
+	//		- compare the expected hashes
 	//		- if they differ, we perform an update of the StatefulSet
 	//		- otherwise, we check if any additional fields (e.g. image)
 	//		  have changed
@@ -179,8 +180,7 @@ func (e *statefulControl) syncPilotResources(c *v1alpha1.ElasticsearchCluster, n
 		return err
 	}
 	for _, pod := range allPods {
-		isMember, err := util.PodControlledByCluster(c, pod, e.statefulSetLister)
-
+		isMember, err := controllers.PodControlledByCluster(c, pod, e.statefulSetLister)
 		if err != nil {
 			return fmt.Errorf("error checking if pod is controller by elasticsearch cluster: %s", err.Error())
 		}

--- a/pkg/controllers/elasticsearch/util/nodepool.go
+++ b/pkg/controllers/elasticsearch/util/nodepool.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	apiv1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	appslisters "k8s.io/client-go/listers/apps/v1beta1"
 
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	hashutil "github.com/jetstack/navigator/pkg/util/hash"
@@ -82,19 +78,4 @@ func SelectorForNodePool(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.Elastics
 		return nil, err
 	}
 	return clusterSelector.Add(*nodePoolNameReq), nil
-}
-
-func PodControlledByCluster(c *v1alpha1.ElasticsearchCluster, pod *apiv1.Pod, ssLister appslisters.StatefulSetLister) (bool, error) {
-	ownerRef := metav1.GetControllerOf(pod)
-	if ownerRef == nil || ownerRef.Kind != "StatefulSet" {
-		return false, nil
-	}
-	ss, err := ssLister.StatefulSets(pod.Namespace).Get(ownerRef.Name)
-	if apierrors.IsNotFound(err) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return metav1.IsControlledBy(ss, c), nil
 }

--- a/pkg/controllers/util_api.go
+++ b/pkg/controllers/util_api.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appslisters "k8s.io/client-go/listers/apps/v1beta1"
+)
+
+func PodControlledByCluster(
+	cluster metav1.Object,
+	pod *apiv1.Pod,
+	ssLister appslisters.StatefulSetLister,
+) (bool, error) {
+	if metav1.IsControlledBy(pod, cluster) {
+		return true, nil
+	}
+	ownerRef := metav1.GetControllerOf(pod)
+	if ownerRef == nil {
+		return false, nil
+	}
+	if ownerRef.Kind != "StatefulSet" {
+		return false, nil
+	}
+	set, err := ssLister.StatefulSets(pod.Namespace).Get(ownerRef.Name)
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return metav1.IsControlledBy(set, cluster), nil
+}


### PR DESCRIPTION
 * For every pod in the nodepool, create a corresponding Pilot resource.
 * Delete Pilot resources for which there is no corresponding Pod.
 * Ignore Pods that are not owned by the cluster.
 * Stop and error if we encounter Pilots with expected name, but not owned by the cluster.
    
Fixes: #152

**Release note**:
```release-note
NONE
```
