### PR TITLE
Increase the timeout for Ready and Liveness probes

### DIFF
--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -66,16 +66,15 @@ function kube_event_exists() {
     return 1
 }
 
-function kube_simulate_unresponsive_process() {
+function simulate_unresponsive_cassandra_process() {
     local namespace=$1
     local pod=$2
     local container=$3
-    # Send STOP signal to all processes in the root process group
-    # https://unix.stackexchange.com/a/149756
+    # Send STOP signal to all the cassandra user's processes
     kubectl \
         --namespace="${namespace}" \
         exec "${pod}" --container="${container}" -- \
-        kill -SIGSTOP --  -1
+        bash -c 'kill -SIGSTOP -- $(ps -u cassandra -o pid=) && ps faux'
 }
 
 function stdout_equals() {


### PR DESCRIPTION
* Increase the timeout for Ready and Liveness probes.
* Use a lower failure threshold for readiness probe, so that the CQL service bypasses a dead node faster.
* Use a larger success threshold for readiness probe, so that traffic isn't redirected to a node until it has been consistently stable.
* Fix a bug in the simulation of a dead node. I was stopping all processes in the container, including the readiness and liveness probes themselves, if that happened to be running.
* Wait until both nodes in the 2-node cluster are *ready*, before commencing the dead node bypass test.

Fixes: #154
Fixes: #160

**Release note**:
```release-note
NONE
```
