### PR TITLE
Pilot service account and RBAC policy

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -207,12 +207,6 @@ function test_cassandracluster() {
 
     kubectl create namespace "${namespace}"
 
-    # XXX Temporary work around until cassandra controller manages RBAC
-    kubectl create --namespace "${namespace}" \
-            rolebinding "${namespace}-binding" \
-            --clusterrole=cluster-admin \
-            --serviceaccount="${namespace}:default"
-
     if ! kubectl get \
          --namespace "${namespace}" \
          CassandraClusters; then

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -47,6 +47,7 @@ func StatefulSetForCluster(
 					Labels: nodePoolLabels,
 				},
 				Spec: apiv1.PodSpec{
+					ServiceAccountName: util.ServiceAccountName(cluster),
 					Volumes: []apiv1.Volume{
 						apiv1.Volume{
 							Name: sharedVolumeName,

--- a/pkg/controllers/cassandra/role/control.go
+++ b/pkg/controllers/cassandra/role/control.go
@@ -1,0 +1,90 @@
+package role
+
+import (
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+	rbacv1 "k8s.io/api/rbac/v1beta1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	rbaclisters "k8s.io/client-go/listers/rbac/v1beta1"
+
+	"k8s.io/client-go/tools/record"
+)
+
+type Interface interface {
+	Sync(*v1alpha1.CassandraCluster) error
+}
+
+type control struct {
+	kubeClient kubernetes.Interface
+	roleLister rbaclisters.RoleLister
+	recorder   record.EventRecorder
+}
+
+var _ Interface = &control{}
+
+func NewControl(
+	kubeClient kubernetes.Interface,
+	roleLister rbaclisters.RoleLister,
+	recorder record.EventRecorder,
+) *control {
+	return &control{
+		kubeClient: kubeClient,
+		roleLister: roleLister,
+		recorder:   recorder,
+	}
+}
+
+func (c *control) Sync(cluster *v1alpha1.CassandraCluster) error {
+	newRole := RoleForCluster(cluster)
+	client := c.kubeClient.RbacV1beta1().Roles(newRole.Namespace)
+	_, err := c.roleLister.
+		Roles(newRole.Namespace).
+		Get(newRole.Name)
+	if k8sErrors.IsNotFound(err) {
+		_, err = client.Create(newRole)
+	}
+	return err
+}
+
+func RoleForCluster(cluster *v1alpha1.CassandraCluster) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.PilotRBACRoleName(cluster),
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				util.NewControllerRef(cluster),
+			},
+			Labels: util.ClusterLabels(cluster),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Verbs:     []string{"create", "update", "patch"},
+				Resources: []string{"events"},
+			},
+			{
+				APIGroups: []string{""},
+				Verbs:     []string{"create", "update", "patch", "get", "list", "watch"},
+				Resources: []string{"configmaps"},
+			},
+			{
+				APIGroups: []string{navigator.GroupName},
+				Verbs:     []string{"get", "list", "watch"},
+				Resources: []string{
+					"pilots",
+					"cassandraclusters",
+				},
+			},
+			{
+				APIGroups: []string{navigator.GroupName},
+				Verbs:     []string{"update", "patch"},
+				Resources: []string{
+					"pilots/status",
+				},
+			},
+		},
+	}
+}

--- a/pkg/controllers/cassandra/role/control_test.go
+++ b/pkg/controllers/cassandra/role/control_test.go
@@ -1,0 +1,40 @@
+package role_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/role"
+	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
+)
+
+func TestRoleSync(t *testing.T) {
+	t.Run(
+		"role missing",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			f.Run()
+			f.AssertRolesLength(1)
+		},
+	)
+	t.Run(
+		"role exists",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			existingRole := role.RoleForCluster(f.Cluster)
+			f.AddObjectK(existingRole)
+			f.Run()
+			f.AssertRolesLength(1)
+		},
+	)
+	t.Run(
+		"sync fails",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			f.RoleControl = &casstesting.FakeControl{
+				SyncError: fmt.Errorf("simulated sync error"),
+			}
+			f.RunExpectError()
+		},
+	)
+}

--- a/pkg/controllers/cassandra/rolebinding/control.go
+++ b/pkg/controllers/cassandra/rolebinding/control.go
@@ -1,0 +1,72 @@
+package rolebinding
+
+import (
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+	rbacv1 "k8s.io/api/rbac/v1beta1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	rbaclisters "k8s.io/client-go/listers/rbac/v1beta1"
+
+	"k8s.io/client-go/tools/record"
+)
+
+type Interface interface {
+	Sync(*v1alpha1.CassandraCluster) error
+}
+
+type control struct {
+	kubeClient        kubernetes.Interface
+	roleBindingLister rbaclisters.RoleBindingLister
+	recorder          record.EventRecorder
+}
+
+var _ Interface = &control{}
+
+func NewControl(
+	kubeClient kubernetes.Interface,
+	roleBindingLister rbaclisters.RoleBindingLister,
+	recorder record.EventRecorder,
+) *control {
+	return &control{
+		kubeClient:        kubeClient,
+		roleBindingLister: roleBindingLister,
+		recorder:          recorder,
+	}
+}
+
+func (c *control) Sync(cluster *v1alpha1.CassandraCluster) error {
+	newRoleBinding := RoleBindingForCluster(cluster)
+	client := c.kubeClient.RbacV1beta1().RoleBindings(newRoleBinding.Namespace)
+	_, err := c.roleBindingLister.
+		RoleBindings(newRoleBinding.Namespace).
+		Get(newRoleBinding.Name)
+	if k8sErrors.IsNotFound(err) {
+		_, err = client.Create(newRoleBinding)
+	}
+	return err
+}
+
+func RoleBindingForCluster(cluster *v1alpha1.CassandraCluster) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.PilotRBACRoleName(cluster),
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				util.NewControllerRef(cluster),
+			},
+			Labels: util.ClusterLabels(cluster),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: rbacv1.ServiceAccountKind,
+				Name: util.ServiceAccountName(cluster),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: util.PilotRBACRoleName(cluster),
+		},
+	}
+}

--- a/pkg/controllers/cassandra/rolebinding/control_test.go
+++ b/pkg/controllers/cassandra/rolebinding/control_test.go
@@ -1,0 +1,40 @@
+package rolebinding_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/rolebinding"
+	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
+)
+
+func TestRoleBindingSync(t *testing.T) {
+	t.Run(
+		"role missing",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			f.Run()
+			f.AssertRoleBindingsLength(1)
+		},
+	)
+	t.Run(
+		"role exists",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			existingRoleBinding := rolebinding.RoleBindingForCluster(f.Cluster)
+			f.AddObjectK(existingRoleBinding)
+			f.Run()
+			f.AssertRoleBindingsLength(1)
+		},
+	)
+	t.Run(
+		"sync fails",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			f.RoleBindingControl = &casstesting.FakeControl{
+				SyncError: fmt.Errorf("simulated sync error"),
+			}
+			f.RunExpectError()
+		},
+	)
+}

--- a/pkg/controllers/cassandra/serviceaccount/control.go
+++ b/pkg/controllers/cassandra/serviceaccount/control.go
@@ -1,0 +1,61 @@
+package serviceaccount
+
+import (
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+	"k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+type Interface interface {
+	Sync(*v1alpha1.CassandraCluster) error
+}
+
+type control struct {
+	kubeClient           kubernetes.Interface
+	serviceAccountLister corelisters.ServiceAccountLister
+	recorder             record.EventRecorder
+}
+
+var _ Interface = &control{}
+
+func NewControl(
+	kubeClient kubernetes.Interface,
+	serviceAccountLister corelisters.ServiceAccountLister,
+	recorder record.EventRecorder,
+) *control {
+	return &control{
+		kubeClient:           kubeClient,
+		serviceAccountLister: serviceAccountLister,
+		recorder:             recorder,
+	}
+}
+
+func (c *control) Sync(cluster *v1alpha1.CassandraCluster) error {
+	newAccount := ServiceAccountForCluster(cluster)
+	client := c.kubeClient.CoreV1().ServiceAccounts(newAccount.Namespace)
+	_, err := c.serviceAccountLister.
+		ServiceAccounts(newAccount.Namespace).
+		Get(newAccount.Name)
+	if k8sErrors.IsNotFound(err) {
+		_, err = client.Create(newAccount)
+	}
+	return err
+}
+
+func ServiceAccountForCluster(cluster *v1alpha1.CassandraCluster) *v1.ServiceAccount {
+	return &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.ServiceAccountName(cluster),
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				util.NewControllerRef(cluster),
+			},
+			Labels: util.ClusterLabels(cluster),
+		},
+	}
+}

--- a/pkg/controllers/cassandra/serviceaccount/control_test.go
+++ b/pkg/controllers/cassandra/serviceaccount/control_test.go
@@ -1,0 +1,40 @@
+package serviceaccount_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/serviceaccount"
+	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
+)
+
+func TestServiceAccountSync(t *testing.T) {
+	t.Run(
+		"service account missing",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			f.Run()
+			f.AssertServiceAccountsLength(1)
+		},
+	)
+	t.Run(
+		"service account exists",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			existingServiceaccount := serviceaccount.ServiceAccountForCluster(f.Cluster)
+			f.AddObjectK(existingServiceaccount)
+			f.Run()
+			f.AssertServiceAccountsLength(1)
+		},
+	)
+	t.Run(
+		"sync fails",
+		func(t *testing.T) {
+			f := casstesting.NewFixture(t)
+			f.ServiceAccountControl = &casstesting.FakeControl{
+				SyncError: fmt.Errorf("simulated sync error"),
+			}
+			f.RunExpectError()
+		},
+	)
+}

--- a/pkg/controllers/cassandra/util/util.go
+++ b/pkg/controllers/cassandra/util/util.go
@@ -44,6 +44,14 @@ func CqlServiceName(c *v1alpha1.CassandraCluster) string {
 	return fmt.Sprintf("%s-cql", ResourceBaseName(c))
 }
 
+func ServiceAccountName(c *v1alpha1.CassandraCluster) string {
+	return ResourceBaseName(c)
+}
+
+func PilotRBACRoleName(c *v1alpha1.CassandraCluster) string {
+	return fmt.Sprintf("%s-pilot", ResourceBaseName(c))
+}
+
 func ClusterLabels(c *v1alpha1.CassandraCluster) map[string]string {
 	return map[string]string{
 		"app":               "cassandracluster",


### PR DESCRIPTION
* Add a service account for Pilots
* and a corresponding RBAC policy which allows pilots to update their pilot resources.

Fixes: #161
**Release note**:
```release-note
NONE
```
