### PR TITLE
WIP: Notes and modifications to allow testing ES pilot in isolation

### DIFF
--- a/Dockerfile.pilot-elasticsearch
+++ b/Dockerfile.pilot-elasticsearch
@@ -1,5 +1,5 @@
-FROM alpine:3.6
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.2
 
 ADD navigator-pilot-elasticsearch_linux_amd64 /pilot
-
+VOLUME /etc/pilot/elasticsearch/config
 ENTRYPOINT ["/pilot"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,33 @@ eval $(minikube docker-env)
 make BUILD_TAG=latest e2e-test
 ```
 
+## Pilot Testing
+
+```
+kubectl proxy --address 192.168.129.43 --accept-hosts='^.*$' -v 100
+
+kubectl create ns foo
+
+kubectl --namespace foo create -f hack/testpilot.yaml
+
+sudo sysctl -w vm.max_map_count=262144
+
+docker run \
+    --name pes \
+    --rm \
+    --volume $PWD/hack/testdata/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro pes  \
+    --master http://192.168.129.43:8001 \
+    --elasticsearch-master-url http://172.17.0.2:9200 \
+    --pilot-namespace foo -v 100 \
+    --pilot-name bar \
+    --elasticsearch-roles master,ingest,data \
+    --logtostderr
+
+docker exec -it pes curl http://localhost:9200
+
+docker stop pes -t 60
+```
+
 ## Credits
 
 An open-source project by [Jetstack.io](https://www.jetstack.io/).

--- a/hack/testdata/elasticsearch.yml
+++ b/hack/testdata/elasticsearch.yml
@@ -1,0 +1,2 @@
+network.host: 0.0.0.0
+xpack.security.enabled: false

--- a/hack/testdata/testpilot.yaml
+++ b/hack/testdata/testpilot.yaml
@@ -1,0 +1,13 @@
+apiVersion: navigator.jetstack.io/v1alpha1
+kind: Pilot
+metadata:
+  name: bar
+  namespace: foo
+  ownerReferences:
+  - apiVersion: navigator.jetstack.io/v1alpha1
+    kind: ElasticsearchCluster
+    name: escluster
+    uid: 23c88696-cf7b-11e7-9ec9-0a580a200927
+    controller: true
+spec:
+  elasticsearch: {}


### PR DESCRIPTION
@munnerz Here's a quick dump of the changes I made and the commands I ran to test the es pilot from my laptop.

And actually, I find that the pilot does shutdown after sigterm, so long as I've added the `xpack.security.enabled: false` config line.

**Release note**:
```release-note
NONE
```
