### PR TITLE
Parameterise ES cluster yaml in tests

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 set -eux
 
+
 : ${TEST_PREFIX:=""}
+
+: ${NAVIGATOR_IMAGE_REPOSITORY:="jetstackexperimental"}
+: ${NAVIGATOR_IMAGE_TAG:="build"}
+: ${NAVIGATOR_IMAGE_PULLPOLICY:="Never"}
+
+export \
+    NAVIGATOR_IMAGE_REPOSITORY \
+    NAVIGATOR_IMAGE_TAG \
+    NAVIGATOR_IMAGE_PULLPOLICY
 
 NAVIGATOR_NAMESPACE="navigator"
 RELEASE_NAME="nav-e2e"
@@ -104,7 +114,11 @@ function test_elasticsearchcluster() {
     # Create and delete an ElasticSearchCluster
     if ! kubectl create \
             --namespace "${namespace}" \
-            --filename "${SCRIPT_DIR}/testdata/es-cluster-test.yaml"; then
+            --filename \
+            <(envsubst \
+                  '$NAVIGATOR_IMAGE_REPOSITORY:$NAVIGATOR_IMAGE_TAG:$NAVIGATOR_IMAGE_PULLPOLICY' \
+                  < "${SCRIPT_DIR}/testdata/es-cluster-test.template.yaml")
+    then
         fail_test "Failed to create elasticsearchcluster"
     fi
     if ! kubectl get \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eux
 
+: ${TEST_PREFIX:=""}
+
 NAVIGATOR_NAMESPACE="navigator"
 RELEASE_NAME="nav-e2e"
 
@@ -130,12 +132,14 @@ function test_elasticsearchcluster() {
     fi
 }
 
-ES_TEST_NS="test-elasticsearchcluster-${TEST_ID}"
-test_elasticsearchcluster "${ES_TEST_NS}"
-if [ "${FAILURE_COUNT}" -gt "0" ]; then
-    fail_and_exit "${ES_TEST_NS}"
+if [[ "test_elasticsearchcluster" = "${TEST_PREFIX}"* ]]; then
+    ES_TEST_NS="test-elasticsearchcluster-${TEST_ID}"
+    test_elasticsearchcluster "${ES_TEST_NS}"
+    if [ "${FAILURE_COUNT}" -gt "0" ]; then
+        fail_and_exit "${ES_TEST_NS}"
+    fi
+    kube_delete_namespace_and_wait "${ES_TEST_NS}"
 fi
-kube_delete_namespace_and_wait "${ES_TEST_NS}"
 
 function cql_connect() {
     local namespace="${1}"
@@ -238,9 +242,11 @@ function test_cassandracluster() {
     fi
 }
 
-CASS_TEST_NS="test-cassandra-${TEST_ID}"
-test_cassandracluster "${CASS_TEST_NS}"
-if [ "${FAILURE_COUNT}" -gt "0" ]; then
-    fail_and_exit "${CASS_TEST_NS}"
+if [[ "test_cassandracluster" = "${TEST_PREFIX}"* ]]; then
+    CASS_TEST_NS="test-cassandra-${TEST_ID}"
+    test_cassandracluster "${CASS_TEST_NS}"
+    if [ "${FAILURE_COUNT}" -gt "0" ]; then
+        fail_and_exit "${CASS_TEST_NS}"
+    fi
+    kube_delete_namespace_and_wait "${CASS_TEST_NS}"
 fi
-kube_delete_namespace_and_wait "${CASS_TEST_NS}"

--- a/hack/testdata/es-cluster-test.template.yaml
+++ b/hack/testdata/es-cluster-test.template.yaml
@@ -7,9 +7,9 @@ spec:
   - vm.max_map_count=262144
 
   pilot:
-    repository: jetstackexperimental/navigator-pilot-elasticsearch
-    tag: build
-    pullPolicy: Never
+    repository: ${NAVIGATOR_IMAGE_REPOSITORY}/navigator-pilot-elasticsearch
+    tag: ${NAVIGATOR_IMAGE_TAG}
+    pullPolicy: ${NAVIGATOR_IMAGE_PULLPOLICY}
 
   image:
     repository: docker.elastic.co/elasticsearch/elasticsearch


### PR DESCRIPTION
Allows me to override the ES pilot image parameters when I'm running tests manually on GKE.

Using `envsubst` as a much lighter weight alternative to using helm chart. Discovered via: https://github.com/kubernetes/kubernetes/issues/23896#issuecomment-303480182


Stacked on #177 

**Release note**:
```release-note
NONE
```
