### PR TITLE
Fix ES cluster Role controller test flake

### DIFF
--- a/pkg/controllers/elasticsearch/role/controller_test.go
+++ b/pkg/controllers/elasticsearch/role/controller_test.go
@@ -114,10 +114,8 @@ func filterInformerActions(actions []core.Action) []core.Action {
 	ret := []core.Action{}
 	for _, action := range actions {
 		if len(action.GetNamespace()) == 0 &&
-			(action.Matches("list", "foos") ||
-				action.Matches("watch", "foos") ||
-				action.Matches("list", "deployments") ||
-				action.Matches("watch", "deployments")) {
+			(action.Matches("list", "roles") ||
+				action.Matches("watch", "roles")) {
 			continue
 		}
 		ret = append(ret, action)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a flakey test in the Elasticsearch role controller by filtering out list/watch events.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #106 

**Release note**:
```release-note
NONE
```
