### PR TITLE
Report ElasticsearchCluster health status to API

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -145,7 +145,7 @@ function test_elasticsearchcluster() {
     then
         fail_test "Elasticsearch pilot did not update the document count"
     fi
-    if ! retry TIMEOUT=300 stdout_equals "yellow" kubectl \
+    if ! retry TIMEOUT=300 stdout_equals "Yellow" kubectl \
         --namespace "${namespace}" \
         get elasticsearchcluster \
         "test" \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -145,6 +145,14 @@ function test_elasticsearchcluster() {
     then
         fail_test "Elasticsearch pilot did not update the document count"
     fi
+    if ! retry TIMEOUT=300 stdout_equals "yellow" kubectl \
+        --namespace "${namespace}" \
+        get elasticsearchcluster \
+        "test" \
+        "-o=go-template={{.status.health}}"
+    then
+        fail_test "Elasticsearch cluster health status should reflect cluster state"
+    fi
 }
 
 if [[ "test_elasticsearchcluster" = "${TEST_PREFIX}"* ]]; then

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -70,11 +70,20 @@ type ElasticsearchCluster struct {
 
 type ElasticsearchClusterStatus struct {
 	NodePools map[string]ElasticsearchClusterNodePoolStatus
+	Health    ElasticsearchClusterHealth
 }
 
 type ElasticsearchClusterNodePoolStatus struct {
 	ReadyReplicas int64
 }
+
+type ElasticsearchClusterHealth string
+
+const (
+	ElasticsearchClusterHealthRed    ElasticsearchClusterHealth = "Red"
+	ElasticsearchClusterHealthYellow ElasticsearchClusterHealth = "Yellow"
+	ElasticsearchClusterHealthGreen  ElasticsearchClusterHealth = "Green"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -71,11 +71,20 @@ type ElasticsearchCluster struct {
 
 type ElasticsearchClusterStatus struct {
 	NodePools map[string]ElasticsearchClusterNodePoolStatus `json:"nodePools"`
+	Health    ElasticsearchClusterHealth                    `json:"health"`
 }
 
 type ElasticsearchClusterNodePoolStatus struct {
 	ReadyReplicas int64 `json:"readyReplicas"`
 }
+
+type ElasticsearchClusterHealth string
+
+const (
+	ElasticsearchClusterHealthRed    ElasticsearchClusterHealth = "Red"
+	ElasticsearchClusterHealthYellow ElasticsearchClusterHealth = "Yellow"
+	ElasticsearchClusterHealthGreen  ElasticsearchClusterHealth = "Green"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -409,6 +409,7 @@ func Convert_navigator_ElasticsearchClusterSpec_To_v1alpha1_ElasticsearchCluster
 
 func autoConvert_v1alpha1_ElasticsearchClusterStatus_To_navigator_ElasticsearchClusterStatus(in *ElasticsearchClusterStatus, out *navigator.ElasticsearchClusterStatus, s conversion.Scope) error {
 	out.NodePools = *(*map[string]navigator.ElasticsearchClusterNodePoolStatus)(unsafe.Pointer(&in.NodePools))
+	out.Health = navigator.ElasticsearchClusterHealth(in.Health)
 	return nil
 }
 
@@ -419,6 +420,7 @@ func Convert_v1alpha1_ElasticsearchClusterStatus_To_navigator_ElasticsearchClust
 
 func autoConvert_navigator_ElasticsearchClusterStatus_To_v1alpha1_ElasticsearchClusterStatus(in *navigator.ElasticsearchClusterStatus, out *ElasticsearchClusterStatus, s conversion.Scope) error {
 	out.NodePools = *(*map[string]ElasticsearchClusterNodePoolStatus)(unsafe.Pointer(&in.NodePools))
+	out.Health = ElasticsearchClusterHealth(in.Health)
 	return nil
 }
 

--- a/pkg/controllers/elasticsearch/role/resources.go
+++ b/pkg/controllers/elasticsearch/role/resources.go
@@ -41,6 +41,7 @@ func roleForCluster(c *v1alpha1.ElasticsearchCluster) *rbacv1beta1.Role {
 				Verbs:     []string{"update", "patch"},
 				Resources: []string{
 					"pilots/status",
+					"elasticsearchclusters/status",
 				},
 			},
 		},

--- a/pkg/pilot/elasticsearch/v5/controller.go
+++ b/pkg/pilot/elasticsearch/v5/controller.go
@@ -44,9 +44,11 @@ func (p *Pilot) updateNodeStats(pilot *v1alpha1.Pilot) error {
 	if err != nil {
 		return err
 	}
+	glog.V(4).Infof("Got %d nodes in returned data", len(statsList.Nodes))
 	// we can iterate over the results as the elastic client should only return
 	// a single node entry or none as we specify a single nodeID.
-	for _, stats := range statsList.Nodes {
+	for name, stats := range statsList.Nodes {
+		glog.V(4).Infof("Applying stats for node %q", name)
 		docCount := stats.Indices.Docs.Count
 		pilot.Status.Elasticsearch.Documents = &docCount
 	}

--- a/pkg/pilot/elasticsearch/v5/controller.go
+++ b/pkg/pilot/elasticsearch/v5/controller.go
@@ -3,6 +3,7 @@ package v5
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -105,10 +106,22 @@ func (p *Pilot) updateElasticsearchClusterStatus(ctx context.Context, esc *v1alp
 	}
 
 	escCopy := esc.DeepCopy()
-	escCopy.Status.Health = v1alpha1.ElasticsearchClusterHealth(currentHealth.Status)
+	escCopy.Status.Health = parseHealth(currentHealth.Status)
 	if _, err := p.navigatorClient.NavigatorV1alpha1().ElasticsearchClusters(escCopy.Namespace).UpdateStatus(escCopy); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func parseHealth(s string) v1alpha1.ElasticsearchClusterHealth {
+	switch strings.ToLower(s) {
+	case "green":
+		return v1alpha1.ElasticsearchClusterHealthGreen
+	case "yellow":
+		return v1alpha1.ElasticsearchClusterHealthYellow
+	case "red":
+		return v1alpha1.ElasticsearchClusterHealthRed
+	}
+	return v1alpha1.ElasticsearchClusterHealth(s)
 }

--- a/pkg/pilot/elasticsearch/v5/controller_test.go
+++ b/pkg/pilot/elasticsearch/v5/controller_test.go
@@ -1,0 +1,47 @@
+package v5
+
+import (
+	"testing"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+)
+
+func TestParseHealth(t *testing.T) {
+	type testT struct {
+		str      string
+		expected v1alpha1.ElasticsearchClusterHealth
+	}
+	tests := []testT{
+		{
+			str:      "grEeN",
+			expected: v1alpha1.ElasticsearchClusterHealthGreen,
+		},
+		{
+			str:      "reD",
+			expected: v1alpha1.ElasticsearchClusterHealthRed,
+		},
+		{
+			str:      "YELLOW",
+			expected: v1alpha1.ElasticsearchClusterHealthYellow,
+		},
+		{
+			str:      "abcdefgh",
+			expected: "abcdefgh",
+		},
+		{
+			str:      "ABCdef",
+			expected: "ABCdef",
+		},
+	}
+	testFn := func(test testT) func(*testing.T) {
+		return func(t *testing.T) {
+			actual := parseHealth(test.str)
+			if actual != test.expected {
+				t.Errorf("Expected health status to equal %s but got %s", test.expected, actual)
+			}
+		}
+	}
+	for _, test := range tests {
+		t.Run("", testFn(test))
+	}
+}

--- a/pkg/pilot/elasticsearch/v5/pilot.go
+++ b/pkg/pilot/elasticsearch/v5/pilot.go
@@ -3,6 +3,7 @@ package v5
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/golang/glog"
 	"gopkg.in/olivere/elastic.v5"
@@ -34,6 +35,8 @@ type Pilot struct {
 
 	// a reference to the GenericPilot for this Pilot
 	genericPilot *genericpilot.GenericPilot
+
+	lastNodeStatsUpdate time.Time
 }
 
 func NewPilot(opts *PilotOptions) (*Pilot, error) {

--- a/pkg/pilot/genericpilot/controller/genericpilot.go
+++ b/pkg/pilot/genericpilot/controller/genericpilot.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
 	informersv1alpha1 "github.com/jetstack/navigator/pkg/client/informers/externalversions/navigator/v1alpha1"
 	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
 	"github.com/jetstack/navigator/pkg/pilot/genericpilot/controller/scheduler"
 )
 
@@ -76,15 +76,7 @@ func NewController(opts Options) *Controller {
 	}
 	ctrl.scheduledWorkQueue = scheduler.NewScheduledWorkQueue(ctrl.enqueuePilot)
 
-	opts.PilotInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: ctrl.enqueuePilot,
-		UpdateFunc: func(old, new interface{}) {
-			if !reflect.DeepEqual(old, new) {
-				ctrl.enqueuePilot(new)
-			}
-		},
-		DeleteFunc: ctrl.enqueuePilot,
-	})
+	opts.PilotInformer.Informer().AddEventHandler(&controllers.QueuingEventHandler{queue})
 
 	return ctrl
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for recording the health status of the Elasticsearch cluster back to the API.

This also introduces a 10s collection delay to the collection of node metrics for Elasticsearch.

**Which issue this PR fixes**:
fixes #191 

**Release note**:
```release-note
Record overall Elasticsearch cluster health as status on the ElasticsearchCluster resource
```
