### PR TITLE
Use pilotName as selector when getting document count

### DIFF
--- a/pkg/pilot/elasticsearch/v5/controller.go
+++ b/pkg/pilot/elasticsearch/v5/controller.go
@@ -26,7 +26,7 @@ func (p *Pilot) syncFunc(pilot *v1alpha1.Pilot) error {
 		return fmt.Errorf("local elasticsearch client not available")
 	}
 	// TODO: use context with a timeout
-	statsList, err := p.localESClient.NodesStats().NodeId(elasticsearchLocalNodeID).Do(context.Background())
+	statsList, err := p.localESClient.NodesStats().NodeId(p.Options.GenericPilotOptions.PilotName).Do(context.Background())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue when reporting the document count where another nodes document count could be returned from the Elasticsearch API, causing controllers to flap and creating extra load on the navigator-apiserver (up to ~10-15RPS created with stats flip-flopping).

**Release note**:
```release-note
Fix bugs in Pilot document count reporting
```
