### PR TITLE
Rename fsGroup to runAsUser and set RunAsUser on ES pods

### DIFF
--- a/hack/testdata/es-cluster-test.template.yaml
+++ b/hack/testdata/es-cluster-test.template.yaml
@@ -19,7 +19,7 @@ spec:
     ## This sets the group of the persistent volume created for
     ## the data nodes. This must be the same as the user that elasticsearch
     ## runs as within the container.
-    fsGroup: 1000
+    runAsUser: 1000
 
   nodePools:
   - name: mixed

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -143,7 +143,7 @@ type ElasticsearchPilotImage struct {
 
 type ElasticsearchImage struct {
 	ImageSpec
-	FsGroup int64
+	RunAsUser int64
 }
 
 // +genclient

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -200,8 +200,9 @@ type ElasticsearchPilotImage struct {
 
 type ElasticsearchImage struct {
 	ImageSpec `json:",inline"`
-	// FsGroup specifies the user that the should be set for the pods fsGroup
-	FsGroup int64 `json:"fsGroup"`
+
+	// RunAsUser specifies the user that the pod should be run as
+	RunAsUser int64 `json:"runAsUser"`
 }
 
 // +genclient

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -453,7 +453,7 @@ func autoConvert_v1alpha1_ElasticsearchImage_To_navigator_ElasticsearchImage(in 
 	if err := Convert_v1alpha1_ImageSpec_To_navigator_ImageSpec(&in.ImageSpec, &out.ImageSpec, s); err != nil {
 		return err
 	}
-	out.FsGroup = in.FsGroup
+	out.RunAsUser = in.RunAsUser
 	return nil
 }
 
@@ -466,7 +466,7 @@ func autoConvert_navigator_ElasticsearchImage_To_v1alpha1_ElasticsearchImage(in 
 	if err := Convert_navigator_ImageSpec_To_v1alpha1_ImageSpec(&in.ImageSpec, &out.ImageSpec, s); err != nil {
 		return err
 	}
-	out.FsGroup = in.FsGroup
+	out.RunAsUser = in.RunAsUser
 	return nil
 }
 

--- a/pkg/apis/navigator/validation/elasticsearch_test.go
+++ b/pkg/apis/navigator/validation/elasticsearch_test.go
@@ -38,7 +38,7 @@ var (
 
 	validSpecPluginsList = []string{"anything"}
 	validSpecESImage     = navigator.ElasticsearchImage{
-		FsGroup:   int64(1000),
+		RunAsUser: int64(1000),
 		ImageSpec: validImageSpec,
 	}
 	validSpecPilotImage = navigator.ElasticsearchPilotImage{

--- a/pkg/controllers/elasticsearch/nodepool/resources.go
+++ b/pkg/controllers/elasticsearch/nodepool/resources.go
@@ -136,7 +136,7 @@ func elasticsearchPodTemplateSpec(controllerName string, c *v1alpha1.Elasticsear
 			ServiceAccountName:            util.ServiceAccountName(c),
 			NodeSelector:                  np.NodeSelector,
 			SecurityContext: &apiv1.PodSecurityContext{
-				FSGroup: util.Int64Ptr(c.Spec.Image.FsGroup),
+				FSGroup: util.Int64Ptr(c.Spec.Image.RunAsUser),
 			},
 			Volumes:        volumes,
 			InitContainers: buildInitContainers(c, np),
@@ -196,6 +196,7 @@ func elasticsearchPodTemplateSpec(controllerName string, c *v1alpha1.Elasticsear
 						},
 					},
 					SecurityContext: &apiv1.SecurityContext{
+						RunAsUser: util.Int64Ptr(c.Spec.Image.RunAsUser),
 						Capabilities: &apiv1.Capabilities{
 							Add: []apiv1.Capability{
 								apiv1.Capability("IPC_LOCK"),


### PR DESCRIPTION
**What this PR does / why we need it**:

This renames the 'fsGroup' field to 'runAsUser', and additionally sets the `runAsUser` fields on pods created by the controller. This fixes issues where there may be a mistmatch between the fsGroup specified and the actual user in the image.

**Special notes for your reviewer**:

This is required for 6.x support

**Release note**:
```release-note
Rename 'fsGroup' to 'runAsUser' and add support for Elasticsearch 6.x
```

/area elasticsearch
/kind feature