### PR TITLE
Add defaults for ElasticsearchCluster pilot image

### DIFF
--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -126,7 +126,7 @@ type ElasticsearchClusterPersistenceConfig struct {
 type ImageSpec struct {
 	Repository string
 	Tag        string
-	PullPolicy string
+	PullPolicy v1.PullPolicy
 }
 
 type ElasticsearchPilotImage struct {

--- a/pkg/apis/navigator/v1alpha1/defaults.go
+++ b/pkg/apis/navigator/v1alpha1/defaults.go
@@ -1,9 +1,29 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	// TODO: update to quay.io
+	defaultPilotImageRepository = "jetstackexperimental/navigator-pilot-elasticsearch"
+	// TODO: don't use latest
+	defaultPilotImageTag = "latest"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
+}
+
+func SetDefaults_ElasticsearchPilotImage(obj *ElasticsearchPilotImage) {
+	if obj.PullPolicy == "" {
+		obj.PullPolicy = corev1.PullIfNotPresent
+	}
+	if obj.Repository == "" {
+		obj.Repository = defaultPilotImageRepository
+	}
+	if obj.Tag == "" {
+		obj.Tag = defaultPilotImageTag
+	}
 }

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -128,9 +128,9 @@ type ElasticsearchClusterPersistenceConfig struct {
 }
 
 type ImageSpec struct {
-	Repository string `json:"repository"`
-	Tag        string `json:"tag"`
-	PullPolicy string `json:"pullPolicy"`
+	Repository string        `json:"repository"`
+	Tag        string        `json:"tag"`
+	PullPolicy v1.PullPolicy `json:"pullPolicy"`
 }
 
 type ElasticsearchPilotImage struct {

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -500,7 +500,7 @@ func Convert_navigator_ElasticsearchPilotStatus_To_v1alpha1_ElasticsearchPilotSt
 func autoConvert_v1alpha1_ImageSpec_To_navigator_ImageSpec(in *ImageSpec, out *navigator.ImageSpec, s conversion.Scope) error {
 	out.Repository = in.Repository
 	out.Tag = in.Tag
-	out.PullPolicy = in.PullPolicy
+	out.PullPolicy = v1.PullPolicy(in.PullPolicy)
 	return nil
 }
 
@@ -512,7 +512,7 @@ func Convert_v1alpha1_ImageSpec_To_navigator_ImageSpec(in *ImageSpec, out *navig
 func autoConvert_navigator_ImageSpec_To_v1alpha1_ImageSpec(in *navigator.ImageSpec, out *ImageSpec, s conversion.Scope) error {
 	out.Repository = in.Repository
 	out.Tag = in.Tag
-	out.PullPolicy = in.PullPolicy
+	out.PullPolicy = v1.PullPolicy(in.PullPolicy)
 	return nil
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.defaults.go
@@ -28,5 +28,18 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&ElasticsearchCluster{}, func(obj interface{}) { SetObjectDefaults_ElasticsearchCluster(obj.(*ElasticsearchCluster)) })
+	scheme.AddTypeDefaultingFunc(&ElasticsearchClusterList{}, func(obj interface{}) { SetObjectDefaults_ElasticsearchClusterList(obj.(*ElasticsearchClusterList)) })
 	return nil
+}
+
+func SetObjectDefaults_ElasticsearchCluster(in *ElasticsearchCluster) {
+	SetDefaults_ElasticsearchPilotImage(&in.Spec.Pilot)
+}
+
+func SetObjectDefaults_ElasticsearchClusterList(in *ElasticsearchClusterList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_ElasticsearchCluster(a)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a defaulting function for the Elasticsearch pilot image spec. This makes `pilot` an optional field.

**Special notes for your reviewer**:

We need to think about how this will update over time. Currently, it's up to the end users of the cluster to ensure the pilot version used is compatible with/within a reasonable range of navigator.

navigator-controller needs to support periodically updating the pilot image specified on Cassandra/ElasticsearchCluster resources, thus triggering the regular cluster upgrade procedure. i'm going to open a separate issue to track this as this is a larger design decision.

**Release note**:
```release-note
Make 'spec.pilot' an optional field on ElasticsearchClusters
```
