### PR TITLE
Verify Gopkg.lock is up to date in CI

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -413,6 +413,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4a3de3f9ba0a0a82ab6389c61ad9d687c89faf9b71690cfb8448680dfb95f841"
+  inputs-digest = "0f80d8f24db098826960ed96d2dae78d3315c1b22372a816b8d15bd616324298"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build: $(CMDS)
 
 generate: .generate_files
 
-verify: .hack_verify go_verify helm_verify
+verify: .hack_verify dep_verify go_verify helm_verify
 
 .hack_verify:
 	@echo Running repo-infra verify scripts
@@ -53,6 +53,9 @@ verify: .hack_verify go_verify helm_verify
 	@${HACK_DIR}/verify-errexit.sh
 	@echo Running generated client checker:
 	@${HACK_DIR}/verify-client-gen.sh
+
+dep_verify:
+	${HACK_DIR}/verify-deps.sh
 
 # Docker targets
 ################

--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+dep ensure -no-vendor -dry-run


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensures our Gopkg.lock is up to date as part of `make verify` with a new target, `make dep_verify`.

**Release note**:
```release-note
NONE
```
