### PR TITLE
 Use goimports for lint checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,7 @@ go_test:
 	go test -v $$(go list ./... | grep -v '/vendor/')
 
 go_fmt:
-	@set -e; \
-	GO_FMT=$$(git ls-files *.go | grep -v 'vendor/' | xargs gofmt -d); \
-	if [ -n "$${GO_FMT}" ] ; then \
-		echo "Please run go fmt"; \
-		echo "$$GO_FMT"; \
-		exit 1; \
-	fi
+	./hack/verify-lint.sh
 
 # This section contains the code generation stuff
 #################################################

--- a/cmd/pilot-cassandra/main.go
+++ b/cmd/pilot-cassandra/main.go
@@ -6,9 +6,10 @@ import (
 	"runtime"
 
 	"github.com/golang/glog"
-	"github.com/jetstack/navigator/pkg/pilot/genericpilot/signals"
 	"k8s.io/apiserver/pkg/util/logs"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/jetstack/navigator/pkg/pilot/genericpilot/signals"
 )
 
 func main() {

--- a/cmd/pilot-cassandra/pilot.go
+++ b/cmd/pilot-cassandra/pilot.go
@@ -3,8 +3,9 @@ package main
 import (
 	"io"
 
-	"github.com/jetstack/navigator/pkg/pilot/cassandra/v3"
 	"github.com/spf13/cobra"
+
+	"github.com/jetstack/navigator/pkg/pilot/cassandra/v3"
 )
 
 // NewCommandStartPilot provides a CLI handler for the pilot

--- a/cmd/pilot-elasticsearch/pilot.go
+++ b/cmd/pilot-elasticsearch/pilot.go
@@ -1,9 +1,11 @@
 package main
 
 import (
-	"github.com/jetstack/navigator/pkg/pilot/elasticsearch/v5"
-	"github.com/spf13/cobra"
 	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jetstack/navigator/pkg/pilot/elasticsearch/v5"
 )
 
 // NewCommandStartPilot provides a CLI handler for the pilot

--- a/hack/update-lint.sh
+++ b/hack/update-lint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+cd "${REPO_ROOT}"
+
+# TODO: remove nasty grepping
+LINT_PKGS=$(find . -type f \
+    ! -name 'zz_generated.*' \
+    ! -path './pkg/client/*' \
+    ! -path './vendor/*' | grep '\.go'
+)
+
+goimports -w \
+    -local github.com/jetstack/navigator \
+    ${LINT_PKGS}

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+cd "${REPO_ROOT}"
+
+# TODO: remove nasty grepping
+LINT_PKGS=$(find . -type f \
+    ! -name 'zz_generated.*' \
+    ! -path './pkg/client/*' \
+    ! -path './vendor/*' | grep '\.go'
+)
+
+GO_IMPORTS=$(goimports -d \
+    -local github.com/jetstack/navigator \
+    ${LINT_PKGS} \
+)
+
+if [ -n "${GO_IMPORTS}" ] ; then \
+    echo "Please run ./hack/update-lint.sh"; \
+    echo "$GO_IMPORTS"; \
+    exit 1; \
+fi

--- a/pkg/apis/navigator/v1alpha1/register.go
+++ b/pkg/apis/navigator/v1alpha1/register.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/jetstack/navigator/pkg/apis/navigator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/pkg/controllers/cassandra/cassandra.go
+++ b/pkg/controllers/cassandra/cassandra.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
+	rbacinformers "k8s.io/client-go/informers/rbac/v1beta1"
+
 	navigatorclientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
 	navigatorinformers "github.com/jetstack/navigator/pkg/client/informers/externalversions/navigator/v1alpha1"
 	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
@@ -29,7 +31,6 @@ import (
 	servicecql "github.com/jetstack/navigator/pkg/controllers/cassandra/service/cql"
 	serviceseedprovider "github.com/jetstack/navigator/pkg/controllers/cassandra/service/seedprovider"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/serviceaccount"
-	rbacinformers "k8s.io/client-go/informers/rbac/v1beta1"
 )
 
 // NewCassandra returns a new CassandraController that can be used

--- a/pkg/controllers/cassandra/cluster_control.go
+++ b/pkg/controllers/cassandra/cluster_control.go
@@ -2,6 +2,9 @@ package cassandra
 
 import (
 	"github.com/golang/glog"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/nodepool"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/pilot"
@@ -10,8 +13,6 @@ import (
 	servicecql "github.com/jetstack/navigator/pkg/controllers/cassandra/service/cql"
 	serviceseedprovider "github.com/jetstack/navigator/pkg/controllers/cassandra/service/seedprovider"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/serviceaccount"
-	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
 )
 
 const (

--- a/pkg/controllers/cassandra/nodepool/nodepool.go
+++ b/pkg/controllers/cassandra/nodepool/nodepool.go
@@ -1,12 +1,13 @@
 package nodepool
 
 import (
-	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1beta1"
 	"k8s.io/client-go/tools/record"
+
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 )
 
 type Interface interface {

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -3,12 +3,13 @@ package nodepool
 import (
 	"fmt"
 
-	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 	apps "k8s.io/api/apps/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 )
 
 const (

--- a/pkg/controllers/cassandra/pilot/pilot.go
+++ b/pkg/controllers/cassandra/pilot/pilot.go
@@ -5,12 +5,6 @@ import (
 	"hash/fnv"
 	"reflect"
 
-	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
-	navigator "github.com/jetstack/navigator/pkg/client/clientset/versioned"
-	navlisters "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
-	"github.com/jetstack/navigator/pkg/controllers"
-	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
-	hashutil "github.com/jetstack/navigator/pkg/util/hash"
 	"k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +12,13 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	navigator "github.com/jetstack/navigator/pkg/client/clientset/versioned"
+	navlisters "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+	hashutil "github.com/jetstack/navigator/pkg/util/hash"
 )
 
 const (

--- a/pkg/controllers/cassandra/pilot/pilot_test.go
+++ b/pkg/controllers/cassandra/pilot/pilot_test.go
@@ -5,11 +5,12 @@ import (
 
 	"k8s.io/api/core/v1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/pilot"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func clusterPod(cluster *v1alpha1.CassandraCluster, name string) *v1.Pod {

--- a/pkg/controllers/cassandra/role/control.go
+++ b/pkg/controllers/cassandra/role/control.go
@@ -1,14 +1,15 @@
 package role
 
 import (
-	"github.com/jetstack/navigator/pkg/apis/navigator"
-	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 	rbacv1 "k8s.io/api/rbac/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1beta1"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 
 	"k8s.io/client-go/tools/record"
 )

--- a/pkg/controllers/cassandra/rolebinding/control.go
+++ b/pkg/controllers/cassandra/rolebinding/control.go
@@ -1,13 +1,14 @@
 package rolebinding
 
 import (
-	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 	rbacv1 "k8s.io/api/rbac/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1beta1"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 
 	"k8s.io/client-go/tools/record"
 )

--- a/pkg/controllers/cassandra/service/cql/control.go
+++ b/pkg/controllers/cassandra/service/cql/control.go
@@ -1,11 +1,12 @@
 package cql
 
 import (
-	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
-	serviceutil "github.com/jetstack/navigator/pkg/controllers/cassandra/service/util"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
+
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	serviceutil "github.com/jetstack/navigator/pkg/controllers/cassandra/service/util"
 )
 
 type Interface interface {

--- a/pkg/controllers/cassandra/service/cql/control_test.go
+++ b/pkg/controllers/cassandra/service/cql/control_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	apiv1 "k8s.io/api/core/v1"
+
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/service/cql"
 	servicetesting "github.com/jetstack/navigator/pkg/controllers/cassandra/service/testing"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
-	apiv1 "k8s.io/api/core/v1"
 )
 
 func newFixture(t *testing.T) *casstesting.Fixture {

--- a/pkg/controllers/cassandra/service/cql/resource.go
+++ b/pkg/controllers/cassandra/service/cql/resource.go
@@ -1,11 +1,12 @@
 package cql
 
 import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	serviceutil "github.com/jetstack/navigator/pkg/controllers/cassandra/service/util"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
-	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func ServiceForCluster(

--- a/pkg/controllers/cassandra/service/seedprovider/control.go
+++ b/pkg/controllers/cassandra/service/seedprovider/control.go
@@ -3,10 +3,11 @@ package seedprovider
 import (
 	serviceutil "github.com/jetstack/navigator/pkg/controllers/cassandra/service/util"
 
-	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
+
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
 type Interface interface {

--- a/pkg/controllers/cassandra/service/seedprovider/control_test.go
+++ b/pkg/controllers/cassandra/service/seedprovider/control_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	apiv1 "k8s.io/api/core/v1"
+
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/service/seedprovider"
 	servicetesting "github.com/jetstack/navigator/pkg/controllers/cassandra/service/testing"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
-	apiv1 "k8s.io/api/core/v1"
 )
 
 func newFixture(t *testing.T) *casstesting.Fixture {

--- a/pkg/controllers/cassandra/service/seedprovider/resource.go
+++ b/pkg/controllers/cassandra/service/seedprovider/resource.go
@@ -1,10 +1,11 @@
 package seedprovider
 
 import (
+	apiv1 "k8s.io/api/core/v1"
+
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	serviceutil "github.com/jetstack/navigator/pkg/controllers/cassandra/service/util"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
-	apiv1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/pkg/controllers/cassandra/service/testing/testing.go
+++ b/pkg/controllers/cassandra/service/testing/testing.go
@@ -3,8 +3,9 @@ package testing
 import (
 	"testing"
 
-	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 	apiv1 "k8s.io/api/core/v1"
+
+	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 )
 
 type FixtureFactory func(t *testing.T) *casstesting.Fixture

--- a/pkg/controllers/cassandra/service/util/util.go
+++ b/pkg/controllers/cassandra/service/util/util.go
@@ -4,11 +4,12 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
-	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 )
 
 func SetStandardServiceAttributes(

--- a/pkg/controllers/cassandra/serviceaccount/control.go
+++ b/pkg/controllers/cassandra/serviceaccount/control.go
@@ -1,14 +1,15 @@
 package serviceaccount
 
 import (
-	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
-	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 	"k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 )
 
 type Interface interface {

--- a/pkg/controllers/cassandra/testing/testing.go
+++ b/pkg/controllers/cassandra/testing/testing.go
@@ -3,8 +3,9 @@ package testing
 import (
 	"testing"
 
-	navinformers "github.com/jetstack/navigator/pkg/client/informers/externalversions"
 	rbacv1 "k8s.io/api/rbac/v1beta1"
+
+	navinformers "github.com/jetstack/navigator/pkg/client/informers/externalversions"
 
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra"
@@ -19,13 +20,14 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	navigatorfake "github.com/jetstack/navigator/pkg/client/clientset/versioned/fake"
 	apps "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+
+	navigatorfake "github.com/jetstack/navigator/pkg/client/clientset/versioned/fake"
 )
 
 func ClusterForTest() *v1alpha1.CassandraCluster {

--- a/pkg/controllers/elasticsearch/nodepool/controller.go
+++ b/pkg/controllers/elasticsearch/nodepool/controller.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/golang/glog"
+
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
 	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"

--- a/pkg/pilot/cassandra/v3/pilot.go
+++ b/pkg/pilot/cassandra/v3/pilot.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/golang/glog"
+
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
 	listersv1alpha1 "github.com/jetstack/navigator/pkg/client/listers/navigator/v1alpha1"

--- a/pkg/pilot/genericpilot/hook/hook.go
+++ b/pkg/pilot/genericpilot/hook/hook.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
+
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 


### PR DESCRIPTION
This switches us to use goimports for linting of files. It performs the same role as gofmt, plus also checks import paths and makes sure they are grouped according to guidelines.

For reference, the 'correct' format:

```go
import (
    // stdlib packages
    "fmt"
    "os/exec"

    // external packages
    "github.com/golang/glog"
    "k8s.io/apimachinery/pkg/apis/meta/v1"

    // packages belonging to our repo
    "github.com/jetstack/navigator/pkg/apis/v1alpha1"
)
```

**Release note**:
```release-note
NONE
```
