### PR TITLE
Cassandra pilot leader election

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -128,6 +128,7 @@ func startLeaderElection(opts *options.ControllerOptions, leaderElectionClient k
 	}
 
 	// Lock required for leader election
+	// TODO Switch to ConfigMap based leader election for consistency with Pilot leader election.
 	rl := resourcelock.EndpointsLock{
 		EndpointsMeta: metav1.ObjectMeta{
 			Namespace: opts.LeaderElectionNamespace,

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -146,6 +146,12 @@ function test_elasticsearchcluster() {
     then
         fail_test "Elasticsearch pod did not enter 'Running' phase"
     fi
+    # A Pilot is elected leader
+    if ! retry TIMEOUT=300 kube_event_exists "${namespace}" \
+         "generic-pilot:ConfigMap:Normal:LeaderElection"
+    then
+        fail_test "Elasticsearch pilots did not elect a leader"
+    fi
     # Ensure the Pilot updates the document count on the pilot resource
     if ! retry TIMEOUT=300 stdout_gt 0 kubectl \
          --namespace "${namespace}" \
@@ -221,6 +227,13 @@ function test_cassandracluster() {
          contrib/charts/cassandra \
          --values "${CHART_VALUES_CASSANDRA}" \
          --set replicaCount=1
+
+    # A Pilot is elected leader
+    if ! retry TIMEOUT=300 kube_event_exists "${namespace}" \
+         "generic-pilot:ConfigMap:Normal:LeaderElection"
+    then
+        fail_test "Cassandra pilots did not elect a leader"
+    fi
 
     # Wait 5 minutes for cassandra to start and listen for CQL queries.
     if ! retry TIMEOUT=300 cql_connect \

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -226,7 +226,7 @@ func StatefulSetForCluster(
 								{
 									Name: "LEADER_ELECTION_CONFIG_MAP",
 									// TODO: trim the length of this string
-									Value: fmt.Sprintf("cassandra-%s-leaderelection", c.Name),
+									Value: fmt.Sprintf("cassandra-%s-leaderelection", cluster.Name),
 								},
 							},
 						},

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -74,6 +74,7 @@ func StatefulSetForCluster(
 								"--logtostderr",
 								"--pilot-name=$(POD_NAME)",
 								"--pilot-namespace=$(POD_NAMESPACE)",
+								"--leader-election-config-map=$(LEADER_ELECTION_CONFIG_MAP)",
 							},
 							Image: fmt.Sprintf(
 								"%s:%s",
@@ -221,6 +222,11 @@ func StatefulSetForCluster(
 											FieldPath: "metadata.namespace",
 										},
 									},
+								},
+								{
+									Name: "LEADER_ELECTION_CONFIG_MAP",
+									// TODO: trim the length of this string
+									Value: fmt.Sprintf("cassandra-%s-leaderelection", c.Name),
 								},
 							},
 						},


### PR DESCRIPTION
Adds the `--leader-election-config-map` command line option that allows the Cassandra pilot to know which config map resource to use for leader election.
Also some E2E tests for this feature.

Fixes: #218 

**Release note**:
```release-note
NONE
```
