### PR TITLE
Use the Docker maintained Cassandra 3 image

### DIFF
--- a/contrib/charts/cassandra/templates/cassandracluster.yaml
+++ b/contrib/charts/cassandra/templates/cassandracluster.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app: {{ template "name"  . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   cqlPort: {{ .Values.cqlPort }}
   sysctls:
@@ -15,10 +15,10 @@ spec:
   - name: ringnodes
     replicas: {{ .Values.replicaCount }}
   image:
-    repository: {{ .Values.image.repository }}
-    tag: {{ .Values.image.tag }}
-    pullPolicy: {{ .Values.image.pullPolicy }}
+    repository: {{ .Values.image.repository | quote }}
+    tag: {{ .Values.image.tag | quote }}
+    pullPolicy: {{ .Values.image.pullPolicy | quote }}
   pilotImage:
-    repository: {{ .Values.pilotImage.repository }}
-    tag: {{ .Values.pilotImage.tag }}
-    pullPolicy: {{ .Values.pilotImage.pullPolicy }}
+    repository: {{ .Values.pilotImage.repository | quote }}
+    tag: {{ .Values.pilotImage.tag | quote }}
+    pullPolicy: {{ .Values.pilotImage.pullPolicy | quote }}

--- a/contrib/charts/cassandra/values.yaml
+++ b/contrib/charts/cassandra/values.yaml
@@ -4,8 +4,8 @@
 replicaCount: 1
 cqlPort: 9042
 image:
-  repository: gcr.io/google-samples/cassandra
-  tag: v12
+  repository: cassandra
+  tag: "3"
   pullPolicy: IfNotPresent
 pilotImage:
   repository: jetstackexperimental/navigator-pilot-cassandra

--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -1,15 +1,15 @@
 apiVersion: navigator.jetstack.io/v1alpha1
 kind: CassandraCluster
 metadata:
-  name: demo
+  name: "demo"
 spec:
   cqlPort: 9042
   sysctls:
   - vm.max_map_count=0
   nodePools:
-  - name: RingNodes
+  - name: "RingNodes"
     replicas: 3
   image:
-    repository: gcr.io/google-samples/cassandra
-    tag: v12
-    pullPolicy: IfNotPresent
+    repository: "cassandra"
+    tag: "3"
+    pullPolicy: "IfNotPresent"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -189,15 +189,12 @@ function cql_connect() {
     # No queries are performed.
     # stdin=false (the default) ensures that cqlsh does not go into interactive
     # mode.
-    # XXX: This uses the standard Cassandra Docker image rather than the
-    # gcr.io/google-samples/cassandra image used in the Cassandra chart, becasue
-    # cqlsh is missing some dependencies in that image.
     kubectl \
         run \
         "cql-responding-${RANDOM}" \
         --namespace="${namespace}" \
         --command=true \
-        --image=cassandra:latest \
+        --image=cassandra:3 \
         --restart=Never \
         --rm \
         --stdin=false \

--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -89,11 +89,11 @@ function simulate_unresponsive_cassandra_process() {
     local namespace=$1
     local pod=$2
     local container=$3
-    # Send STOP signal to all the cassandra user's processes
+    # Decommission causes cassandra to stop accepting CQL connections.
     kubectl \
         --namespace="${namespace}" \
         exec "${pod}" --container="${container}" -- \
-        bash -c 'kill -SIGSTOP -- $(ps -u cassandra -o pid=) && ps faux'
+        nodetool decommission
 }
 
 function stdout_equals() {

--- a/pkg/pilot/cassandra/v3/pilot.go
+++ b/pkg/pilot/cassandra/v3/pilot.go
@@ -53,9 +53,7 @@ func (p *Pilot) Hooks() *hook.Hooks {
 }
 
 func (p *Pilot) CmdFunc(pilot *v1alpha1.Pilot) (*exec.Cmd, error) {
-	// The /run.sh script is unique to gcr.io/google-samples/cassandra:v12.
-	// TODO: Add support for other Cassandra images with different entry points.
-	cmd := exec.Command("/run.sh")
+	cmd := exec.Command("/docker-entrypoint.sh")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd, nil


### PR DESCRIPTION
* Use the Docker maintained Cassandra 3 image.
* Use TCP connect based readiness and liveness probe because this image doesn't contain a nodetool based `/ready-probe.sh` script.
* These TCP connection checks will succeed even though the process is stopped; so I now simulate a node failure using `nodetool decommission` which makes cassandra stop listening on its CQL port.
* I can improve on this when #170 is merged. 

Fixes: #222 

**Release note**:
```release-note
NONE
```
