### PR TITLE
Switch replicas fields to use int32 instead of int64

### DIFF
--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -76,7 +76,7 @@ type ElasticsearchClusterStatus struct {
 }
 
 type ElasticsearchClusterNodePoolStatus struct {
-	ReadyReplicas int64
+	ReadyReplicas int32
 }
 
 type ElasticsearchClusterHealth string
@@ -106,15 +106,15 @@ type ElasticsearchClusterSpec struct {
 	Image          *ImageSpec
 	Plugins        []string
 	NodePools      []ElasticsearchClusterNodePool
-	MinimumMasters int64
+	MinimumMasters int32
 }
 
 type ElasticsearchClusterNodePool struct {
 	Name         string
-	Replicas     int64
+	Replicas     int32
 	Roles        []ElasticsearchClusterRole
 	NodeSelector map[string]string
-	Resources    *v1.ResourceRequirements
+	Resources    v1.ResourceRequirements
 	Persistence  ElasticsearchClusterPersistenceConfig
 }
 

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -81,7 +81,7 @@ type ElasticsearchClusterStatus struct {
 // pool in an ElasticsearchCluster
 type ElasticsearchClusterNodePoolStatus struct {
 	// ReadyReplicas is the total number of ready pods in this cluster.
-	ReadyReplicas int64 `json:"readyReplicas"`
+	ReadyReplicas int32 `json:"readyReplicas"`
 }
 
 type ElasticsearchClusterHealth string
@@ -125,7 +125,7 @@ type ElasticsearchClusterSpec struct {
 	// If omitted, this will be set to a quorum of the master nodes in the
 	// cluster. If set, the value *must* be greater than or equal to a quorum
 	// of master nodes.
-	MinimumMasters int64 `json:"minimumMasters,omitempty"`
+	MinimumMasters int32 `json:"minimumMasters,omitempty"`
 }
 
 // ElasticsearchClusterNodePool describes a node pool within an ElasticsearchCluster.
@@ -135,22 +135,25 @@ type ElasticsearchClusterNodePool struct {
 	Name string `json:"name"`
 
 	// Number of replicas in the pool.
-	Replicas int64 `json:"replicas"`
+	Replicas int32 `json:"replicas"`
 
 	// Roles that nodes in this pool should perform within the cluster.
 	Roles []ElasticsearchClusterRole `json:"roles"`
 
 	// NodeSelector should be specified to force nodes in this pool to run on
 	// nodes matching the given selector.
+	// +optional
 	NodeSelector map[string]string `json:"nodeSelector"`
 
 	// Resources specifies the resource requirements to be used for nodes that
 	// are part of the pool.
-	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
+	// +optional
+	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Persistence specifies the configuration for persistent data for this
 	// node. Disabling persistence can cause issues when nodes restart, so
 	// should only be using for testing purposes.
+	// +optional
 	Persistence ElasticsearchClusterPersistenceConfig `json:"persistence,omitempty"`
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -314,7 +314,7 @@ func autoConvert_v1alpha1_ElasticsearchClusterNodePool_To_navigator_Elasticsearc
 	out.Replicas = in.Replicas
 	out.Roles = *(*[]navigator.ElasticsearchClusterRole)(unsafe.Pointer(&in.Roles))
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Resources = (*v1.ResourceRequirements)(unsafe.Pointer(in.Resources))
+	out.Resources = in.Resources
 	if err := Convert_v1alpha1_ElasticsearchClusterPersistenceConfig_To_navigator_ElasticsearchClusterPersistenceConfig(&in.Persistence, &out.Persistence, s); err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func autoConvert_navigator_ElasticsearchClusterNodePool_To_v1alpha1_Elasticsearc
 	out.Replicas = in.Replicas
 	out.Roles = *(*[]ElasticsearchClusterRole)(unsafe.Pointer(&in.Roles))
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Resources = (*v1.ResourceRequirements)(unsafe.Pointer(in.Resources))
+	out.Resources = in.Resources
 	if err := Convert_navigator_ElasticsearchClusterPersistenceConfig_To_v1alpha1_ElasticsearchClusterPersistenceConfig(&in.Persistence, &out.Persistence, s); err != nil {
 		return err
 	}

--- a/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -244,15 +243,7 @@ func (in *ElasticsearchClusterNodePool) DeepCopyInto(out *ElasticsearchClusterNo
 			(*out)[key] = val
 		}
 	}
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.ResourceRequirements)
-			(*in).DeepCopyInto(*out)
-		}
-	}
+	in.Resources.DeepCopyInto(&out.Resources)
 	in.Persistence.DeepCopyInto(&out.Persistence)
 	return
 }

--- a/pkg/apis/navigator/validation/elasticsearch.go
+++ b/pkg/apis/navigator/validation/elasticsearch.go
@@ -45,8 +45,7 @@ func ValidateElasticsearchClusterNodePool(np *navigator.ElasticsearchClusterNode
 		el = append(el, field.Invalid(fldPath.Child("replicas"), np.Replicas, "must be greater than zero"))
 	}
 	// TODO: call k8s.io/kubernetes/pkg/apis/core/validation.ValidateResourceRequirements on np.Resources
-	// this will require vendoring kubernetes/kubernetes and switching to use the corev1 ResourceRequirements
-	// struct
+	// this will require vendoring kubernetes/kubernetes.
 	return el
 }
 
@@ -106,8 +105,8 @@ func ValidateElasticsearchCluster(esc *navigator.ElasticsearchCluster) field.Err
 	return allErrs
 }
 
-func countElasticsearchMasters(pools []navigator.ElasticsearchClusterNodePool) int64 {
-	masters := int64(0)
+func countElasticsearchMasters(pools []navigator.ElasticsearchClusterNodePool) int32 {
+	masters := int32(0)
 	for _, pool := range pools {
 		if containsElasticsearchRole(pool.Roles, navigator.ElasticsearchRoleMaster) {
 			masters += pool.Replicas

--- a/pkg/apis/navigator/validation/elasticsearch_test.go
+++ b/pkg/apis/navigator/validation/elasticsearch_test.go
@@ -16,13 +16,13 @@ import (
 
 var (
 	validNodePoolName         = "valid-name"
-	validNodePoolReplicas     = int64(5)
+	validNodePoolReplicas     = int32(5)
 	validNodePoolRoles        = []navigator.ElasticsearchClusterRole{navigator.ElasticsearchRoleData}
 	validNodePoolNodeSelector = map[string]string{
 		"some": "selector",
 	}
 	// TODO: expand test cases here
-	validNodePoolResources         = &corev1.ResourceRequirements{}
+	validNodePoolResources         = corev1.ResourceRequirements{}
 	validNodePoolPersistenceConfig = navigator.ElasticsearchClusterPersistenceConfig{
 		Enabled: true,
 		Size:    resource.MustParse("10Gi"),
@@ -40,7 +40,7 @@ var (
 	validSpecPluginsList = []string{"anything"}
 )
 
-func newValidNodePool(name string, replicas int64, roles ...navigator.ElasticsearchClusterRole) navigator.ElasticsearchClusterNodePool {
+func newValidNodePool(name string, replicas int32, roles ...navigator.ElasticsearchClusterRole) navigator.ElasticsearchClusterNodePool {
 	return navigator.ElasticsearchClusterNodePool{
 		Name:         name,
 		Replicas:     replicas,
@@ -187,7 +187,7 @@ func TestValidateElasticsearchClusterNodePool(t *testing.T) {
 		},
 		"negative replicas": {
 			Name:         validNodePoolName,
-			Replicas:     int64(-1),
+			Replicas:     int32(-1),
 			Roles:        validNodePoolRoles,
 			NodeSelector: validNodePoolNodeSelector,
 			Resources:    validNodePoolResources,

--- a/pkg/apis/navigator/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package navigator
 
 import (
-	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -244,15 +243,7 @@ func (in *ElasticsearchClusterNodePool) DeepCopyInto(out *ElasticsearchClusterNo
 			(*out)[key] = val
 		}
 	}
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.ResourceRequirements)
-			(*in).DeepCopyInto(*out)
-		}
-	}
+	in.Resources.DeepCopyInto(&out.Resources)
 	in.Persistence.DeepCopyInto(&out.Persistence)
 	return
 }

--- a/pkg/controllers/elasticsearch/nodepool/controller.go
+++ b/pkg/controllers/elasticsearch/nodepool/controller.go
@@ -135,7 +135,7 @@ func (e *statefulControl) syncNodePool(c *v1alpha1.ElasticsearchCluster, np *v1a
 		}
 	}
 
-	statusCopy.ReadyReplicas = int64(existingStatefulSet.Status.ReadyReplicas)
+	statusCopy.ReadyReplicas = existingStatefulSet.Status.ReadyReplicas
 
 	// the hashes match, which means the properties of the node pool have not changed
 	return statusCopy, nil

--- a/pkg/controllers/elasticsearch/util/nodepool.go
+++ b/pkg/controllers/elasticsearch/util/nodepool.go
@@ -21,13 +21,13 @@ const (
 // ComputeHash returns a hash value calculated from pod template and a collisionCount to avoid hash collision
 func ComputeNodePoolHash(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.ElasticsearchClusterNodePool, collisionCount *int32) string {
 	hashVar := struct {
-		MinimumMasters int64
+		MinimumMasters int32
 		ESImage        *v1alpha1.ImageSpec
 		PilotImage     v1alpha1.ImageSpec
 		Sysctl         []string
 		Plugins        []string
-		Replicas       int64
-		Resources      *corev1.ResourceRequirements
+		Replicas       int32
+		Resources      corev1.ResourceRequirements
 		NodeSelector   map[string]string
 		Roles          []v1alpha1.ElasticsearchClusterRole
 		Version        string

--- a/pkg/util/api/elasticsearch.go
+++ b/pkg/util/api/elasticsearch.go
@@ -4,8 +4,8 @@ import (
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 )
 
-func CountElasticsearchMasters(pools []v1alpha1.ElasticsearchClusterNodePool) int64 {
-	masters := int64(0)
+func CountElasticsearchMasters(pools []v1alpha1.ElasticsearchClusterNodePool) int32 {
+	masters := int32(0)
 	for _, pool := range pools {
 		if ContainsElasticsearchRole(pool.Roles, v1alpha1.ElasticsearchRoleMaster) {
 			masters += pool.Replicas

--- a/pkg/util/api/elasticsearch_test.go
+++ b/pkg/util/api/elasticsearch_test.go
@@ -10,7 +10,7 @@ import (
 func TestCountElasticsearchMasters(t *testing.T) {
 	type testT struct {
 		in    []v1alpha1.ElasticsearchClusterNodePool
-		count int64
+		count int32
 	}
 	tests := []testT{
 		{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,7 +2,7 @@ package util
 
 // CalculateQuorum will return a quorum of the given number. This is useful
 // when calculating configuration parameters for distributed systems.
-func CalculateQuorum(num int64) int64 {
+func CalculateQuorum(num int32) int32 {
 	if num == 0 {
 		return 0
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestCalculateQuorum(t *testing.T) {
 	type testT struct {
-		in  int64
-		out int64
+		in  int32
+		out int32
 	}
 	tests := []testT{
 		{0, 0},


### PR DESCRIPTION
**What this PR does / why we need it**:

Given `replicas` fields on the workloads API objects are all int32, this is in keeping with that and saves the loss of precision.

**Release note**:
```release-note
NONE
```
