### PR TITLE
Add Elasticsearch Pilot version field

### DIFF
--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -198,6 +198,7 @@ type ElasticsearchPilotStatus struct {
 	// an unknown number of documents, whereas 0 indicates that the node is
 	// empty
 	Documents *int64
+	Version   semver.Version
 }
 
 // PilotCondition contains condition information for a Pilot.

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -268,6 +268,8 @@ type ElasticsearchPilotStatus struct {
 	// an unknown number of documents, whereas 0 indicates that the node is
 	// empty
 	Documents *int64 `json:"documents,omitempty"`
+	// Version as reported by the Elasticsearch process
+	Version semver.Version `json:"version,omitempty"`
 }
 
 // PilotCondition contains condition information for a Pilot.

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -445,6 +445,7 @@ func Convert_navigator_ElasticsearchClusterStatus_To_v1alpha1_ElasticsearchClust
 
 func autoConvert_v1alpha1_ElasticsearchPilotStatus_To_navigator_ElasticsearchPilotStatus(in *ElasticsearchPilotStatus, out *navigator.ElasticsearchPilotStatus, s conversion.Scope) error {
 	out.Documents = (*int64)(unsafe.Pointer(in.Documents))
+	out.Version = in.Version
 	return nil
 }
 
@@ -455,6 +456,7 @@ func Convert_v1alpha1_ElasticsearchPilotStatus_To_navigator_ElasticsearchPilotSt
 
 func autoConvert_navigator_ElasticsearchPilotStatus_To_v1alpha1_ElasticsearchPilotStatus(in *navigator.ElasticsearchPilotStatus, out *ElasticsearchPilotStatus, s conversion.Scope) error {
 	out.Documents = (*int64)(unsafe.Pointer(in.Documents))
+	out.Version = in.Version
 	return nil
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
@@ -365,6 +365,7 @@ func (in *ElasticsearchPilotStatus) DeepCopyInto(out *ElasticsearchPilotStatus) 
 			**out = **in
 		}
 	}
+	out.Version = in.Version
 	return
 }
 

--- a/pkg/apis/navigator/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/zz_generated.deepcopy.go
@@ -365,6 +365,7 @@ func (in *ElasticsearchPilotStatus) DeepCopyInto(out *ElasticsearchPilotStatus) 
 			**out = **in
 		}
 	}
+	out.Version = in.Version
 	return
 }
 

--- a/pkg/pilot/elasticsearch/v5/controller.go
+++ b/pkg/pilot/elasticsearch/v5/controller.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,11 +29,19 @@ func (p *Pilot) syncFunc(pilot *v1alpha1.Pilot) error {
 		return nil
 	}
 
-	err := p.updateNodeStats(pilot)
-	return err
+	if err := p.updateNodeStats(pilot); err != nil {
+		return err
+	}
+	if err := p.updateNodeInfo(pilot); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (p *Pilot) updateNodeStats(pilot *v1alpha1.Pilot) error {
+	if pilot.Status.Elasticsearch == nil {
+		pilot.Status.Elasticsearch = &v1alpha1.ElasticsearchPilotStatus{}
+	}
 	// set the ES document count to nil to indicate an unknown number of
 	// documents in case obtaining the document count fails. This prevents the
 	// node being shut down if it is not safe to do so.
@@ -52,6 +61,31 @@ func (p *Pilot) updateNodeStats(pilot *v1alpha1.Pilot) error {
 		glog.V(4).Infof("Applying stats for node %q", name)
 		docCount := stats.Indices.Docs.Count
 		pilot.Status.Elasticsearch.Documents = &docCount
+	}
+	return nil
+}
+func (p *Pilot) updateNodeInfo(pilot *v1alpha1.Pilot) error {
+	if pilot.Status.Elasticsearch == nil {
+		pilot.Status.Elasticsearch = &v1alpha1.ElasticsearchPilotStatus{}
+	}
+	if p.localESClient == nil {
+		return fmt.Errorf("local elasticsearch client not available")
+	}
+	// TODO: use context with a timeout
+	infoList, err := p.localESClient.NodesInfo().NodeId(p.Options.GenericPilotOptions.PilotName).Do(context.Background())
+	if err != nil {
+		return err
+	}
+	glog.V(4).Infof("Got %d nodes in returned data", len(infoList.Nodes))
+	// we can iterate over the results as the elastic client should only return
+	// a single node entry or none as we specify a single nodeID.
+	for name, info := range infoList.Nodes {
+		glog.V(4).Infof("Applying info for node %q", name)
+		ver, err := semver.NewVersion(info.Version)
+		if err != nil {
+			return err
+		}
+		pilot.Status.Elasticsearch.Version = *ver
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `version` field to the Elasticsearch Pilot status fields

**Special notes for your reviewer**:

Merge after #239 

**Release note**:
```release-note
Record ElasticsearchCluster version on Pilot status block
```
