### PR TITLE
Add a CassandraCluster.Version field

### DIFF
--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -3,6 +3,7 @@ kind: "CassandraCluster"
 metadata:
   name: "demo"
 spec:
+  version: "3.11.1"
   cqlPort: 9042
   sysctls:
   - "vm.max_map_count=0"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -194,6 +194,7 @@ function test_cassandracluster() {
     export CASS_NAME="test"
     export CASS_REPLICAS=1
     export CASS_CQL_PORT=9042
+    export CASS_VERSION="3.11.1"
 
     kubectl create namespace "${namespace}"
 
@@ -207,7 +208,7 @@ function test_cassandracluster() {
         --namespace "${namespace}" \
         --filename \
         <(envsubst \
-              '$NAVIGATOR_IMAGE_REPOSITORY:$NAVIGATOR_IMAGE_TAG:$NAVIGATOR_IMAGE_PULLPOLICY:$CASS_NAME:$CASS_REPLICAS:$CASS_CQL_PORT' \
+              '$NAVIGATOR_IMAGE_REPOSITORY:$NAVIGATOR_IMAGE_TAG:$NAVIGATOR_IMAGE_PULLPOLICY:$CASS_NAME:$CASS_REPLICAS:$CASS_CQL_PORT:$CASS_VERSION' \
               < "${SCRIPT_DIR}/testdata/cass-cluster-test.template.yaml")
     then
         fail_test "Failed to create cassandracluster"
@@ -296,7 +297,7 @@ function test_cassandracluster() {
         --namespace "${namespace}" \
         --filename \
         <(envsubst \
-              '$NAVIGATOR_IMAGE_REPOSITORY:$NAVIGATOR_IMAGE_TAG:$NAVIGATOR_IMAGE_PULLPOLICY:$CASS_NAME:$CASS_REPLICAS:$CASS_CQL_PORT' \
+              '$NAVIGATOR_IMAGE_REPOSITORY:$NAVIGATOR_IMAGE_TAG:$NAVIGATOR_IMAGE_PULLPOLICY:$CASS_NAME:$CASS_REPLICAS:$CASS_CQL_PORT:$CASS_VERSION' \
               < "${SCRIPT_DIR}/testdata/cass-cluster-test.template.yaml")
 
     # Wait 60s for cassandra CQL port to change
@@ -313,7 +314,7 @@ function test_cassandracluster() {
         --namespace "${namespace}" \
         --filename \
         <(envsubst \
-              '$NAVIGATOR_IMAGE_REPOSITORY:$NAVIGATOR_IMAGE_TAG:$NAVIGATOR_IMAGE_PULLPOLICY:$CASS_NAME:$CASS_REPLICAS:$CASS_CQL_PORT' \
+              '$NAVIGATOR_IMAGE_REPOSITORY:$NAVIGATOR_IMAGE_TAG:$NAVIGATOR_IMAGE_PULLPOLICY:$CASS_NAME:$CASS_REPLICAS:$CASS_CQL_PORT:$CASS_VERSION' \
               < "${SCRIPT_DIR}/testdata/cass-cluster-test.template.yaml")
 
     if ! retry TIMEOUT=300 stdout_equals 2 kubectl \

--- a/hack/testdata/cass-cluster-test.template.yaml
+++ b/hack/testdata/cass-cluster-test.template.yaml
@@ -3,6 +3,7 @@ kind: "CassandraCluster"
 metadata:
   name: ${CASS_NAME}
 spec:
+  version: "${CASS_VERSION}"
   cqlPort: ${CASS_CQL_PORT}
   sysctls:
   - "vm.max_map_count=0"

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -28,7 +28,8 @@ type CassandraClusterSpec struct {
 	NavigatorClusterConfig
 
 	NodePools []CassandraClusterNodePool
-	Image     ImageSpec
+	Version   semver.Version
+	Image     *ImageSpec
 	CqlPort   int32
 }
 

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -31,8 +31,14 @@ type CassandraClusterSpec struct {
 	NavigatorClusterConfig `json:",inline"`
 
 	NodePools []CassandraClusterNodePool `json:"nodePools"`
-	Image     ImageSpec                  `json:"image"`
-	CqlPort   int32                      `json:"cqlPort"`
+
+	// Image describes the database image to use
+	Image *ImageSpec `json:"image"`
+
+	CqlPort int32 `json:"cqlPort"`
+
+	// The version of the database to be used for nodes in the cluster.
+	Version semver.Version `json:"version"`
 }
 
 // CassandraClusterNodePool describes a node pool within a CassandraCluster.

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -119,7 +119,17 @@ func Convert_navigator_CassandraCluster_To_v1alpha1_CassandraCluster(in *navigat
 
 func autoConvert_v1alpha1_CassandraClusterList_To_navigator_CassandraClusterList(in *CassandraClusterList, out *navigator.CassandraClusterList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]navigator.CassandraCluster)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]navigator.CassandraCluster, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha1_CassandraCluster_To_navigator_CassandraCluster(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -130,7 +140,17 @@ func Convert_v1alpha1_CassandraClusterList_To_navigator_CassandraClusterList(in 
 
 func autoConvert_navigator_CassandraClusterList_To_v1alpha1_CassandraClusterList(in *navigator.CassandraClusterList, out *CassandraClusterList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]CassandraCluster)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]CassandraCluster, len(*in))
+		for i := range *in {
+			if err := Convert_navigator_CassandraCluster_To_v1alpha1_CassandraCluster(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -198,10 +218,9 @@ func autoConvert_v1alpha1_CassandraClusterSpec_To_navigator_CassandraClusterSpec
 		return err
 	}
 	out.NodePools = *(*[]navigator.CassandraClusterNodePool)(unsafe.Pointer(&in.NodePools))
-	if err := Convert_v1alpha1_ImageSpec_To_navigator_ImageSpec(&in.Image, &out.Image, s); err != nil {
-		return err
-	}
+	out.Image = (*navigator.ImageSpec)(unsafe.Pointer(in.Image))
 	out.CqlPort = in.CqlPort
+	out.Version = in.Version
 	return nil
 }
 
@@ -215,9 +234,8 @@ func autoConvert_navigator_CassandraClusterSpec_To_v1alpha1_CassandraClusterSpec
 		return err
 	}
 	out.NodePools = *(*[]CassandraClusterNodePool)(unsafe.Pointer(&in.NodePools))
-	if err := Convert_navigator_ImageSpec_To_v1alpha1_ImageSpec(&in.Image, &out.Image, s); err != nil {
-		return err
-	}
+	out.Version = in.Version
+	out.Image = (*ImageSpec)(unsafe.Pointer(in.Image))
 	out.CqlPort = in.CqlPort
 	return nil
 }

--- a/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
@@ -138,7 +138,16 @@ func (in *CassandraClusterSpec) DeepCopyInto(out *CassandraClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.Image = in.Image
+	if in.Image != nil {
+		in, out := &in.Image, &out.Image
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(ImageSpec)
+			**out = **in
+		}
+	}
+	out.Version = in.Version
 	return
 }
 

--- a/pkg/apis/navigator/validation/cassandra_test.go
+++ b/pkg/apis/navigator/validation/cassandra_test.go
@@ -1,0 +1,87 @@
+package validation_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/apis/navigator/validation"
+)
+
+var (
+	validCassCluster = &navigator.CassandraCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Spec: navigator.CassandraClusterSpec{
+			Version: validSemver,
+			Image:   &validImageSpec,
+			NavigatorClusterConfig: validNavigatorClusterConfig,
+		},
+	}
+)
+
+func TestValidateCassandraCluster(t *testing.T) {
+	type testT struct {
+		cluster       *navigator.CassandraCluster
+		errorExpected bool
+	}
+
+	tests := map[string]testT{
+		"valid cluster": {
+			cluster: validCassCluster,
+		},
+	}
+
+	setNavigatorClusterConfig := func(
+		c *navigator.CassandraCluster,
+		ncc navigator.NavigatorClusterConfig,
+	) *navigator.CassandraCluster {
+		c = c.DeepCopy()
+		c.Spec.NavigatorClusterConfig = ncc
+		return c
+	}
+
+	for title, ncc := range navigatorClusterConfigErrorCases {
+		tests[title] = testT{
+			cluster:       setNavigatorClusterConfig(validCassCluster, ncc),
+			errorExpected: true,
+		}
+	}
+
+	setImage := func(
+		c *navigator.CassandraCluster,
+		image *navigator.ImageSpec,
+	) *navigator.CassandraCluster {
+		c = c.DeepCopy()
+		c.Spec.Image = image
+		return c
+	}
+
+	for title, image := range imageErrorCases {
+		tests[title] = testT{
+			cluster:       setImage(validCassCluster, &image),
+			errorExpected: true,
+		}
+	}
+
+	for title, tc := range tests {
+		t.Run(
+			title,
+			func(t *testing.T) {
+				errs := validation.ValidateCassandraCluster(tc.cluster)
+				if tc.errorExpected && len(errs) == 0 {
+					t.Errorf("expected error but got none")
+				}
+				if !tc.errorExpected && len(errs) != 0 {
+					t.Errorf("unexpected errors: %s", errs)
+				}
+				for _, e := range errs {
+					t.Logf("error string is: %s", e)
+				}
+			},
+		)
+	}
+}

--- a/pkg/apis/navigator/validation/elasticsearch.go
+++ b/pkg/apis/navigator/validation/elasticsearch.go
@@ -3,7 +3,6 @@ package validation
 import (
 	"fmt"
 
-	"github.com/coreos/go-semver/semver"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -59,8 +58,6 @@ func ValidateElasticsearchPersistence(cfg *navigator.PersistenceConfig, fldPath 
 	}
 	return el
 }
-
-var emptySemver = semver.Version{}
 
 func ValidateElasticsearchClusterSpec(spec *navigator.ElasticsearchClusterSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := ValidateNavigatorClusterConfig(&spec.NavigatorClusterConfig, fldPath)

--- a/pkg/apis/navigator/validation/generic.go
+++ b/pkg/apis/navigator/validation/generic.go
@@ -6,6 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/coreos/go-semver/semver"
+
 	"github.com/jetstack/navigator/pkg/apis/navigator"
 )
 
@@ -15,6 +17,8 @@ var supportedPullPolicies = []string{
 	string(corev1.PullAlways),
 	"",
 }
+
+var emptySemver = semver.Version{}
 
 func ValidateImageSpec(img *navigator.ImageSpec, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}

--- a/pkg/apis/navigator/validation/generic_test.go
+++ b/pkg/apis/navigator/validation/generic_test.go
@@ -1,0 +1,46 @@
+package validation_test
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-semver/semver"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+)
+
+var (
+	validSemver          = *semver.New("5.6.2")
+	validImageTag        = "latest"
+	validImageRepo       = "something"
+	validImagePullPolicy = corev1.PullIfNotPresent
+	validImageSpec       = navigator.ImageSpec{
+		Tag:        validImageTag,
+		Repository: validImageRepo,
+		PullPolicy: validImagePullPolicy,
+	}
+	validNavigatorClusterConfig = navigator.NavigatorClusterConfig{
+		PilotImage: validImageSpec,
+	}
+	imageErrorCases = map[string]navigator.ImageSpec{
+		"missing repository": {
+			Tag:        validImageTag,
+			PullPolicy: validImagePullPolicy,
+		},
+		"missing tag": {
+			Repository: validImageRepo,
+			PullPolicy: validImagePullPolicy,
+		},
+	}
+	navigatorClusterConfigErrorCases = map[string]navigator.NavigatorClusterConfig{
+		"missing pilot image": {},
+	}
+)
+
+func init() {
+	for title, ec := range imageErrorCases {
+		o := validNavigatorClusterConfig.DeepCopy()
+		o.PilotImage = ec
+		navigatorClusterConfigErrorCases[fmt.Sprintf("pilotimage-%s", title)] = *o
+	}
+}

--- a/pkg/apis/navigator/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/zz_generated.deepcopy.go
@@ -138,7 +138,16 @@ func (in *CassandraClusterSpec) DeepCopyInto(out *CassandraClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.Image = in.Image
+	out.Version = in.Version
+	if in.Image != nil {
+		in, out := &in.Image, &out.Image
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(ImageSpec)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -39,7 +39,6 @@ func StatefulSetForCluster(
 	statefulSetName := util.NodePoolResourceName(cluster, np)
 	seedProviderServiceName := util.SeedProviderServiceName(cluster)
 	nodePoolLabels := util.NodePoolLabels(cluster, np.Name)
-
 	datacenter := cassDefaultDatacenter
 	if np.Datacenter != "" {
 		datacenter = np.Datacenter
@@ -49,7 +48,7 @@ func StatefulSetForCluster(
 	if np.Rack != "" {
 		rack = np.Rack
 	}
-
+	image := cassImageToUse(&cluster.Spec)
 	set := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            statefulSetName,
@@ -113,10 +112,10 @@ func StatefulSetForCluster(
 							},
 							Image: fmt.Sprintf(
 								"%s:%s",
-								cluster.Spec.Image.Repository,
-								cluster.Spec.Image.Tag,
+								image.Repository,
+								image.Tag,
 							),
-							ImagePullPolicy: cluster.Spec.Image.PullPolicy,
+							ImagePullPolicy: image.PullPolicy,
 							ReadinessProbe: &apiv1.Probe{
 								Handler: apiv1.Handler{
 									HTTPGet: &apiv1.HTTPGetAction{

--- a/pkg/controllers/cassandra/nodepool/util.go
+++ b/pkg/controllers/cassandra/nodepool/util.go
@@ -1,0 +1,27 @@
+package nodepool
+
+import (
+	"github.com/coreos/go-semver/semver"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+)
+
+func cassImageToUse(spec *v1alpha1.CassandraClusterSpec) *v1alpha1.ImageSpec {
+	if spec.Image == nil {
+		return defaultCassandraImageForVersion(spec.Version)
+	}
+	return spec.Image
+
+}
+
+const defaultCassandraImageRepository = "docker.io/cassandra"
+const defaultCassandraImagePullPolicy = corev1.PullIfNotPresent
+
+func defaultCassandraImageForVersion(v semver.Version) *v1alpha1.ImageSpec {
+	return &v1alpha1.ImageSpec{
+		Repository: defaultCassandraImageRepository,
+		Tag:        v.String(),
+		PullPolicy: defaultCassandraImagePullPolicy,
+	}
+}


### PR DESCRIPTION
* CassandraCluster now has a Version field which must be a valid semver.
* CassandraCluster.Image is now optional
* and if ommitted will default to the image from docker.io/cassandra matching the supplied semver version.
* If Image is supplied, its repository and tag must be supplied, but pullPolicy is optional.
* Created shared test cases for NavigatorClusterConfig validation.
* In the Cassandra helm chart, I've removed the ability to override the cassandra image tag and repository for now, because its not needed in any of the tests.

Fixes: #234


**Release note**:
```release-note
NONE
```
