### PR TITLE
Add apiserver.persistence config stanza to helm chart

### DIFF
--- a/contrib/charts/navigator/templates/apiserver-pvc.yaml
+++ b/contrib/charts/navigator/templates/apiserver-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.apiserver.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-apiserver
+  annotations:
+  {{- if .Values.apiserver.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.apiserver.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.apiserver.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.apiserver.persistence.size | quote }}
+{{- end }}

--- a/contrib/charts/navigator/templates/apiserver.yaml
+++ b/contrib/charts/navigator/templates/apiserver.yaml
@@ -44,5 +44,21 @@ spec:
         - name: etcd
           image: quay.io/coreos/etcd:v3.2.7
           imagePullPolicy: IfNotPresent
+          command:
+          - etcd
+          args:
+          - "-data-dir"
+          - /var/lib/etcd
+          volumeMounts:
+          - name: data
+            mountPath: /var/lib/etcd
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      volumes:
+      - name: data
+{{ if .Values.apiserver.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-apiserver
+{{- else }}
+        emptyDir: {}
+{{- end }}

--- a/contrib/charts/navigator/values.yaml
+++ b/contrib/charts/navigator/values.yaml
@@ -25,6 +25,15 @@ apiserver:
     tag: latest
     pullPolicy: Always
   logLevel: 2
+
+  persistence:
+    enabled: false
+    size: 10Gi
+    accessMode: ReadWriteOnce
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ##
+    # storageClass: ""
+
 controller:
   ## Optional: namespace to watch for resources in. This can be used when RBAC
   ## restricts you to a single namespace.


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows persisting apiserver state with a pvc.

**Which issue this PR fixes**: fixes #135 

**Release note**:
```release-note
Add option to use PVC for persisting apiserver etcd data
```
