### PR TITLE
Add datacenter and rack info to cassandra nodepool spec

### DIFF
--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -7,13 +7,19 @@ spec:
   sysctls:
   - "vm.max_map_count=0"
   nodePools:
-  - name: "RingNodes"
+  - name: "ringnodes"
     replicas: 3
+    datacenter: "demo-datacenter"
+    rack: "demo-rack"
     persistence:
       enabled: true
       size: "5Gi"
       storageClass: "default"
+    nodeSelector:
   image:
     repository: "cassandra"
     tag: "3"
     pullPolicy: "IfNotPresent"
+  pilotImage:
+    repository: "jetstackexperimental/navigator-pilot-cassandra"
+    tag: "canary"

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -33,9 +33,10 @@ type CassandraClusterSpec struct {
 }
 
 type CassandraClusterNodePool struct {
-	Name        string
-	Replicas    int64
-	Persistence PersistenceConfig
+	Name         string
+	Replicas     int64
+	Persistence  PersistenceConfig
+	NodeSelector map[string]string
 }
 
 type CassandraClusterStatus struct {

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -28,7 +28,7 @@ type CassandraClusterSpec struct {
 	NavigatorClusterConfig
 
 	NodePools []CassandraClusterNodePool
-	Image     ImageSpec
+	Image     *ImageSpec
 	CqlPort   int32
 }
 

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -37,6 +37,8 @@ type CassandraClusterNodePool struct {
 	Replicas     int64
 	Persistence  PersistenceConfig
 	NodeSelector map[string]string
+	Rack         string
+	Datacenter   string
 }
 
 type CassandraClusterStatus struct {

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -28,7 +28,7 @@ type CassandraClusterSpec struct {
 	NavigatorClusterConfig
 
 	NodePools []CassandraClusterNodePool
-	Image     *ImageSpec
+	Image     ImageSpec
 	CqlPort   int32
 }
 

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -31,7 +31,7 @@ type CassandraClusterSpec struct {
 	NavigatorClusterConfig `json:",inline"`
 
 	NodePools []CassandraClusterNodePool `json:"nodePools"`
-	Image     ImageSpec                  `json:"image"`
+	Image     *ImageSpec                 `json:"image"`
 	CqlPort   int32                      `json:"cqlPort"`
 }
 

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -49,7 +49,14 @@ type CassandraClusterNodePool struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector"`
 
-	Rack       string `json:"rack"`
+	// Rack specifies the cassandra rack with which to label nodes in this
+	// nodepool. If this is not set, a default will be selected.
+	// +optional
+	Rack string `json:"rack"`
+
+	// Datacenter specifies the cassandra datacenter with which to label nodes
+	// in this nodepool. If this is not set, a default will be selected.
+	// +optional
 	Datacenter string `json:"datacenter"`
 }
 

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -43,6 +43,11 @@ type CassandraClusterNodePool struct {
 	// Persistence specifies the configuration for persistent data for this
 	// node.
 	Persistence PersistenceConfig `json:"persistence,omitempty"`
+
+	// NodeSelector should be specified to force nodes in this pool to run on
+	// nodes matching the given selector.
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector"`
 }
 
 type CassandraClusterStatus struct {

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -31,7 +31,7 @@ type CassandraClusterSpec struct {
 	NavigatorClusterConfig `json:",inline"`
 
 	NodePools []CassandraClusterNodePool `json:"nodePools"`
-	Image     *ImageSpec                 `json:"image"`
+	Image     ImageSpec                  `json:"image"`
 	CqlPort   int32                      `json:"cqlPort"`
 }
 

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -48,6 +48,9 @@ type CassandraClusterNodePool struct {
 	// nodes matching the given selector.
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector"`
+
+	Rack       string `json:"rack"`
+	Datacenter string `json:"datacenter"`
 }
 
 type CassandraClusterStatus struct {

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -145,6 +145,7 @@ func autoConvert_v1alpha1_CassandraClusterNodePool_To_navigator_CassandraCluster
 	if err := Convert_v1alpha1_PersistenceConfig_To_navigator_PersistenceConfig(&in.Persistence, &out.Persistence, s); err != nil {
 		return err
 	}
+	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	return nil
 }
 
@@ -159,6 +160,7 @@ func autoConvert_navigator_CassandraClusterNodePool_To_v1alpha1_CassandraCluster
 	if err := Convert_navigator_PersistenceConfig_To_v1alpha1_PersistenceConfig(&in.Persistence, &out.Persistence, s); err != nil {
 		return err
 	}
+	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	return nil
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -198,9 +198,7 @@ func autoConvert_v1alpha1_CassandraClusterSpec_To_navigator_CassandraClusterSpec
 		return err
 	}
 	out.NodePools = *(*[]navigator.CassandraClusterNodePool)(unsafe.Pointer(&in.NodePools))
-	if err := Convert_v1alpha1_ImageSpec_To_navigator_ImageSpec(&in.Image, &out.Image, s); err != nil {
-		return err
-	}
+	out.Image = (*navigator.ImageSpec)(unsafe.Pointer(in.Image))
 	out.CqlPort = in.CqlPort
 	return nil
 }
@@ -215,9 +213,7 @@ func autoConvert_navigator_CassandraClusterSpec_To_v1alpha1_CassandraClusterSpec
 		return err
 	}
 	out.NodePools = *(*[]CassandraClusterNodePool)(unsafe.Pointer(&in.NodePools))
-	if err := Convert_navigator_ImageSpec_To_v1alpha1_ImageSpec(&in.Image, &out.Image, s); err != nil {
-		return err
-	}
+	out.Image = (*ImageSpec)(unsafe.Pointer(in.Image))
 	out.CqlPort = in.CqlPort
 	return nil
 }

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -198,7 +198,9 @@ func autoConvert_v1alpha1_CassandraClusterSpec_To_navigator_CassandraClusterSpec
 		return err
 	}
 	out.NodePools = *(*[]navigator.CassandraClusterNodePool)(unsafe.Pointer(&in.NodePools))
-	out.Image = (*navigator.ImageSpec)(unsafe.Pointer(in.Image))
+	if err := Convert_v1alpha1_ImageSpec_To_navigator_ImageSpec(&in.Image, &out.Image, s); err != nil {
+		return err
+	}
 	out.CqlPort = in.CqlPort
 	return nil
 }
@@ -213,7 +215,9 @@ func autoConvert_navigator_CassandraClusterSpec_To_v1alpha1_CassandraClusterSpec
 		return err
 	}
 	out.NodePools = *(*[]CassandraClusterNodePool)(unsafe.Pointer(&in.NodePools))
-	out.Image = (*ImageSpec)(unsafe.Pointer(in.Image))
+	if err := Convert_navigator_ImageSpec_To_v1alpha1_ImageSpec(&in.Image, &out.Image, s); err != nil {
+		return err
+	}
 	out.CqlPort = in.CqlPort
 	return nil
 }

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -146,6 +146,8 @@ func autoConvert_v1alpha1_CassandraClusterNodePool_To_navigator_CassandraCluster
 		return err
 	}
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
+	out.Rack = in.Rack
+	out.Datacenter = in.Datacenter
 	return nil
 }
 
@@ -161,6 +163,8 @@ func autoConvert_navigator_CassandraClusterNodePool_To_v1alpha1_CassandraCluster
 		return err
 	}
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
+	out.Rack = in.Rack
+	out.Datacenter = in.Datacenter
 	return nil
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
@@ -138,15 +138,7 @@ func (in *CassandraClusterSpec) DeepCopyInto(out *CassandraClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Image != nil {
-		in, out := &in.Image, &out.Image
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ImageSpec)
-			**out = **in
-		}
-	}
+	out.Image = in.Image
 	return
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
@@ -138,7 +138,15 @@ func (in *CassandraClusterSpec) DeepCopyInto(out *CassandraClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.Image = in.Image
+	if in.Image != nil {
+		in, out := &in.Image, &out.Image
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(ImageSpec)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
@@ -91,6 +91,13 @@ func (in *CassandraClusterList) DeepCopyObject() runtime.Object {
 func (in *CassandraClusterNodePool) DeepCopyInto(out *CassandraClusterNodePool) {
 	*out = *in
 	in.Persistence.DeepCopyInto(&out.Persistence)
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/navigator/validation/cassandra.go
+++ b/pkg/apis/navigator/validation/cassandra.go
@@ -50,9 +50,7 @@ func ValidateCassandraClusterUpdate(old, new *navigator.CassandraCluster) field.
 
 func ValidateCassandraClusterSpec(spec *navigator.CassandraClusterSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := ValidateNavigatorClusterConfig(&spec.NavigatorClusterConfig, fldPath)
-	if spec.Image != nil {
-		allErrs = append(allErrs, ValidateImageSpec(spec.Image, fldPath.Child("image"))...)
-	}
+
 	npPath := fldPath.Child("nodePools")
 	allNames := sets.String{}
 	for i, np := range spec.NodePools {

--- a/pkg/apis/navigator/validation/cassandra.go
+++ b/pkg/apis/navigator/validation/cassandra.go
@@ -2,18 +2,43 @@ package validation
 
 import (
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/jetstack/navigator/pkg/apis/navigator"
 )
 
-func ValidateCassandraCluster(esc *navigator.CassandraCluster) field.ErrorList {
-	allErrs := ValidateObjectMeta(&esc.ObjectMeta, true, apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateCassandraClusterSpec(&esc.Spec, field.NewPath("spec"))...)
+func ValidateCassandraClusterNodePool(np *navigator.CassandraClusterNodePool, fldPath *field.Path) field.ErrorList {
+	return field.ErrorList{}
+}
+
+func ValidateCassandraCluster(cass *navigator.CassandraCluster) field.ErrorList {
+	allErrs := ValidateObjectMeta(&cass.ObjectMeta, true, apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
+	allErrs = append(allErrs, ValidateCassandraClusterSpec(&cass.Spec, field.NewPath("spec"))...)
+	return allErrs
+}
+
+func ValidateCassandraClusterUpdate(old, new *navigator.CassandraCluster) field.ErrorList {
+	allErrs := ValidateCassandraCluster(new)
+
 	return allErrs
 }
 
 func ValidateCassandraClusterSpec(spec *navigator.CassandraClusterSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := ValidateNavigatorClusterConfig(&spec.NavigatorClusterConfig, fldPath)
+	if spec.Image != nil {
+		allErrs = append(allErrs, ValidateImageSpec(spec.Image, fldPath.Child("image"))...)
+	}
+	npPath := fldPath.Child("nodePools")
+	allNames := sets.String{}
+	for i, np := range spec.NodePools {
+		idxPath := npPath.Index(i)
+		if allNames.Has(np.Name) {
+			allErrs = append(allErrs, field.Duplicate(idxPath.Child("name"), np.Name))
+		} else {
+			allNames.Insert(np.Name)
+		}
+		allErrs = append(allErrs, ValidateCassandraClusterNodePool(&np, idxPath)...)
+	}
 	return allErrs
 }

--- a/pkg/apis/navigator/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/zz_generated.deepcopy.go
@@ -138,15 +138,7 @@ func (in *CassandraClusterSpec) DeepCopyInto(out *CassandraClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Image != nil {
-		in, out := &in.Image, &out.Image
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ImageSpec)
-			**out = **in
-		}
-	}
+	out.Image = in.Image
 	return
 }
 

--- a/pkg/apis/navigator/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/zz_generated.deepcopy.go
@@ -138,7 +138,15 @@ func (in *CassandraClusterSpec) DeepCopyInto(out *CassandraClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.Image = in.Image
+	if in.Image != nil {
+		in, out := &in.Image, &out.Image
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(ImageSpec)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/navigator/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/zz_generated.deepcopy.go
@@ -91,6 +91,13 @@ func (in *CassandraClusterList) DeepCopyObject() runtime.Object {
 func (in *CassandraClusterNodePool) DeepCopyInto(out *CassandraClusterNodePool) {
 	*out = *in
 	in.Persistence.DeepCopyInto(&out.Persistence)
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -21,6 +21,8 @@ const (
 	cassDataVolumeName      = "cassandra-data"
 	cassDataVolumeMountPath = "/var/lib/cassandra"
 
+	cassSnitch = "GossipingPropertyFileSnitch"
+
 	// See https://jolokia.org/reference/html/agents.html#jvm-agent
 	jolokiaHost    = "127.0.0.1"
 	jolokiaPort    = 8778
@@ -202,7 +204,7 @@ func StatefulSetForCluster(
 								},
 								{
 									Name:  "CASSANDRA_ENDPOINT_SNITCH",
-									Value: "GossipingPropertyFileSnitch",
+									Value: cassSnitch,
 								},
 								{
 									Name:  "CASSANDRA_SERVICE",

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -23,6 +23,8 @@ const (
 
 	cassSnitch = "GossipingPropertyFileSnitch"
 
+	cassDefaultDatacenter = "navigator-default-datacenter"
+
 	// See https://jolokia.org/reference/html/agents.html#jvm-agent
 	jolokiaHost    = "127.0.0.1"
 	jolokiaPort    = 8778
@@ -38,7 +40,7 @@ func StatefulSetForCluster(
 	seedProviderServiceName := util.SeedProviderServiceName(cluster)
 	nodePoolLabels := util.NodePoolLabels(cluster, np.Name)
 
-	datacenter := "navigator-default-datacenter"
+	datacenter := cassDefaultDatacenter
 	if np.Datacenter != "" {
 		datacenter = np.Datacenter
 	}

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -35,6 +35,17 @@ func StatefulSetForCluster(
 	statefulSetName := util.NodePoolResourceName(cluster, np)
 	seedProviderServiceName := util.SeedProviderServiceName(cluster)
 	nodePoolLabels := util.NodePoolLabels(cluster, np.Name)
+
+	datacenter := "navigator-default-datacenter"
+	if np.Datacenter != "" {
+		datacenter = np.Datacenter
+	}
+
+	rack := "navigator-default-rack"
+	if np.Rack != "" {
+		rack = np.Rack
+	}
+
 	set := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            statefulSetName,
@@ -190,6 +201,10 @@ func StatefulSetForCluster(
 									),
 								},
 								{
+									Name:  "CASSANDRA_ENDPOINT_SNITCH",
+									Value: "GossipingPropertyFileSnitch",
+								},
+								{
 									Name:  "CASSANDRA_SERVICE",
 									Value: seedProviderServiceName,
 								},
@@ -199,11 +214,11 @@ func StatefulSetForCluster(
 								},
 								{
 									Name:  "CASSANDRA_DC",
-									Value: "DC1-K8Demo",
+									Value: datacenter,
 								},
 								{
 									Name:  "CASSANDRA_RACK",
-									Value: "Rack1-K8Demo",
+									Value: rack,
 								},
 								{
 									Name: "JVM_OPTS",

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -59,6 +59,7 @@ func StatefulSetForCluster(
 				},
 				Spec: apiv1.PodSpec{
 					ServiceAccountName: util.ServiceAccountName(cluster),
+					NodeSelector:       np.NodeSelector,
 					Volumes: []apiv1.Volume{
 						apiv1.Volume{
 							Name: sharedVolumeName,

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -43,7 +43,7 @@ func StatefulSetForCluster(
 		datacenter = np.Datacenter
 	}
 
-	rack := "navigator-default-rack"
+	rack := np.Name
 	if np.Rack != "" {
 		rack = np.Rack
 	}

--- a/pkg/registry/navigator/cassandracluster/strategy.go
+++ b/pkg/registry/navigator/cassandracluster/strategy.go
@@ -89,8 +89,10 @@ func (cassandraClusterStrategy) Canonicalize(obj runtime.Object) {
 }
 
 func (cassandraClusterStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	cass := obj.(*navigator.CassandraCluster)
-	return validation.ValidateCassandraCluster(cass)
+	newCassandraCluster := obj.(*navigator.CassandraCluster)
+	oldCassandraCluster := old.(*navigator.CassandraCluster)
+
+	return validation.ValidateCassandraClusterUpdate(oldCassandraCluster, newCassandraCluster)
 }
 
 // implements interface RESTUpdateStrategy. This implementation validates updates to


### PR DESCRIPTION
This adds three fields to cassandra's nodepool spec:
- `nodeSelector`
- `rack`
- `datacenter`

`nodeSelector` is passed to the statefulset spec, allowing users to specify where the nodepool is scheduled.

`rack` and `datacenter` are both passed to cassandra's GossipingPropertyFileSnitch, which distributes this information around the rest of the cluster.

Fixes #247 

```release-note
Add datacenter and rack info to cassandra nodepool spec
```