### PR TITLE
Add CreateNodePool and ScaleOut actions for Cassandra

### DIFF
--- a/docs/cassandra.rst
+++ b/docs/cassandra.rst
@@ -176,3 +176,55 @@ For example, you could use the `Datastax Python driver <http://datastax.github.i
    depends on the DNS server and operating system configuration.
 
 .. include:: supplementary-resources.rst
+
+The Life Cycle of a Navigator Cassandra Cluster
+-----------------------------------------------
+
+Changes to the configuration of an established Cassandra cluster must be carefully sequenced in order to maintain the health of the cluster.
+So Navigator is conservative about the configuration changes that it supports.
+
+Here are the configuration changes that are supported and the configuration changes which are not yet supported.
+
+Supported Configuration Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Navigator supports the following changes to a Cassandra cluster:
+
+ * :ref:`create-cluster-cassandra`: Add all initially configured node pools and nodes.
+ * :ref:`scale-out-cassandra`: Increase ``CassandraCluster.Spec.NodePools[0].Replicas`` to add more C* nodes to a ``nodepool``.
+
+Navigator does not currently support any other changes to the Cassandra cluster configuration.
+
+Unsupported Configuration Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following configuration changes are not currently supported but will be supported in the near future:
+
+ * Minor Upgrade: Trigger a rolling Cassandra upgrade by increasing the minor and / or patch components of ``CassandraCluster.Spec.Version``.
+ * Scale In: Decrease ``CassandraCluster.Spec.NodePools[0].Replicas`` to remove C* nodes from a ``nodepool``.
+
+The following configuration changes are not currently supported:
+ * Add Rack: Add a ``nodepool`` for a new rack.
+ * Remove Rack: Remove a ``nodepool``.
+ * Add Data Center: Add a ``nodepool`` for a new data center.
+ * Remove Data Center: Remove all the ``nodepools`` in a data center.
+ * Major Upgrade: Upgrade to a new major Cassandra version.
+
+.. _create-cluster-cassandra:
+
+Create Cluster
+~~~~~~~~~~~~~~
+
+When you first create a ``CassandraCluster`` resource, Navigator will add nodes, one at a time,
+in order of ``NodePool`` and according to the process described in :ref:`scale-out-cassandra` (below).
+The order of node creation is determined by the order of the entries in the ``CassandraCluster.Spec.NodePools`` list.
+You can look at ``CassandraCluster.Status.NodePools`` to see the current state.
+
+.. _scale-out-cassandra:
+
+Scale Out
+~~~~~~~~~
+
+When you first create a cluster or when you increment the ``CassandraCluster.Spec.NodePools[i].ReplicaCount``,
+Navigator will add C* nodes, one at a time, until the desired number of nodes is reached.
+You can look at ``CassandraCluster.Status.NodePools[<nodepoolname>].ReadyReplicas`` to see the current number of healthy C* nodes in each ``nodepool``.

--- a/internal/test/util/generate/generate.go
+++ b/internal/test/util/generate/generate.go
@@ -118,3 +118,28 @@ func StatefulSet(c StatefulSetConfig) *apps.StatefulSet {
 		},
 	}
 }
+
+type CassandraClusterConfig struct {
+	Name, Namespace string
+}
+
+func CassandraCluster(c CassandraClusterConfig) *v1alpha1.CassandraCluster {
+	return &v1alpha1.CassandraCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.Name,
+			Namespace: c.Namespace,
+		},
+	}
+}
+
+type CassandraClusterNodePoolConfig struct {
+	Name     string
+	Replicas int32
+}
+
+func CassandraClusterNodePool(c CassandraClusterNodePoolConfig) *v1alpha1.CassandraClusterNodePool {
+	return &v1alpha1.CassandraClusterNodePool{
+		Name:     c.Name,
+		Replicas: c.Replicas,
+	}
+}

--- a/pkg/controllers/cassandra/actions/create_nodepool.go
+++ b/pkg/controllers/cassandra/actions/create_nodepool.go
@@ -1,0 +1,39 @@
+package actions
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/nodepool"
+)
+
+type CreateNodePool struct {
+	Cluster  *v1alpha1.CassandraCluster
+	NodePool *v1alpha1.CassandraClusterNodePool
+}
+
+var _ controllers.Action = &CreateNodePool{}
+
+func (a *CreateNodePool) Name() string {
+	return "CreateNodePool"
+}
+
+func (a *CreateNodePool) Execute(s *controllers.State) error {
+	ss := nodepool.StatefulSetForCluster(a.Cluster, a.NodePool)
+	_, err := s.Clientset.AppsV1beta1().StatefulSets(ss.Namespace).Create(ss)
+	if k8sErrors.IsAlreadyExists(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	s.Recorder.Eventf(
+		a.Cluster,
+		corev1.EventTypeNormal,
+		a.Name(),
+		"CreateNodePool: Name=%q", a.NodePool.Name,
+	)
+	return nil
+}

--- a/pkg/controllers/cassandra/actions/create_nodepool_test.go
+++ b/pkg/controllers/cassandra/actions/create_nodepool_test.go
@@ -1,0 +1,91 @@
+package actions_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jetstack/navigator/internal/test/unit/framework"
+	"github.com/jetstack/navigator/internal/test/util/generate"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/actions"
+)
+
+func TestCreateNodePool(t *testing.T) {
+	type testT struct {
+		kubeObjects         []runtime.Object
+		cluster             generate.CassandraClusterConfig
+		nodePool            generate.CassandraClusterNodePoolConfig
+		expectedStatefulSet *generate.StatefulSetConfig
+		expectedErr         bool
+	}
+	tests := map[string]testT{
+		"A statefulset is created if one does not already exist": {
+			cluster: generate.CassandraClusterConfig{
+				Name:      "cluster1",
+				Namespace: "ns1",
+			},
+			nodePool: generate.CassandraClusterNodePoolConfig{
+				Name: "pool1",
+			},
+			expectedStatefulSet: &generate.StatefulSetConfig{
+				Name:      "cass-cluster1-pool1",
+				Namespace: "ns1",
+			},
+		},
+		"Idempotent: CreateNodePool can be executed again without error": {
+			kubeObjects: []runtime.Object{
+				generate.StatefulSet(
+					generate.StatefulSetConfig{
+						Name:      "cass-cluster1-pool1",
+						Namespace: "ns1",
+					},
+				),
+			},
+			cluster: generate.CassandraClusterConfig{Name: "cluster1", Namespace: "ns1"},
+			nodePool: generate.CassandraClusterNodePoolConfig{
+				Name: "pool1",
+			},
+			expectedStatefulSet: &generate.StatefulSetConfig{
+				Name:      "cass-cluster1-pool1",
+				Namespace: "ns1",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(
+			name,
+			func(t *testing.T) {
+				fixture := &framework.StateFixture{
+					T:           t,
+					KubeObjects: test.kubeObjects,
+				}
+				fixture.Start()
+				defer fixture.Stop()
+				state := fixture.State()
+				a := &actions.CreateNodePool{
+					Cluster:  generate.CassandraCluster(test.cluster),
+					NodePool: generate.CassandraClusterNodePool(test.nodePool),
+				}
+				err := a.Execute(state)
+				if !test.expectedErr && err != nil {
+					t.Errorf("Unexpected error: %s", err)
+				}
+				if test.expectedErr && err == nil {
+					t.Errorf("Expected an error")
+				}
+				if test.expectedStatefulSet != nil {
+					_, err = fixture.KubeClient().
+						AppsV1beta1().
+						StatefulSets(test.expectedStatefulSet.Namespace).
+						Get(test.expectedStatefulSet.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Fatalf("Unexpected error retrieving statefulset: %v", err)
+					}
+				}
+			},
+		)
+	}
+}

--- a/pkg/controllers/cassandra/actions/scaleout.go
+++ b/pkg/controllers/cassandra/actions/scaleout.go
@@ -1,0 +1,59 @@
+package actions
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/golang/glog"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/nodepool"
+	"github.com/jetstack/navigator/pkg/util/ptr"
+)
+
+type ScaleOut struct {
+	Cluster  *v1alpha1.CassandraCluster
+	NodePool *v1alpha1.CassandraClusterNodePool
+}
+
+var _ controllers.Action = &ScaleOut{}
+
+func (a *ScaleOut) Name() string {
+	return "ScaleOut"
+}
+
+func (a *ScaleOut) Execute(s *controllers.State) error {
+	baseSet := nodepool.StatefulSetForCluster(a.Cluster, a.NodePool)
+	existingSet, err := s.StatefulSetLister.
+		StatefulSets(baseSet.Namespace).Get(baseSet.Name)
+	if err != nil {
+		return err
+	}
+	newSet := existingSet.DeepCopy()
+	if *existingSet.Spec.Replicas == a.NodePool.Replicas {
+		return nil
+	}
+	if *existingSet.Spec.Replicas > a.NodePool.Replicas {
+		glog.Errorf(
+			"ScaleOut error:"+
+				"The StatefulSet.Spec.Replicas value (%d) "+
+				"is greater than the desired value (%d)",
+			*existingSet.Spec.Replicas, a.NodePool.Replicas,
+		)
+		return nil
+	}
+	newSet.Spec.Replicas = ptr.Int32(*newSet.Spec.Replicas + 1)
+	_, err = s.Clientset.AppsV1beta1().
+		StatefulSets(newSet.Namespace).Update(newSet)
+	if err != nil {
+		return err
+	}
+	s.Recorder.Eventf(
+		a.Cluster,
+		corev1.EventTypeNormal,
+		a.Name(),
+		"ScaleOut: NodePool=%q, ReplicaCount=%d, TargetReplicaCount=%d",
+		a.NodePool.Name, *newSet.Spec.Replicas, a.NodePool.Replicas,
+	)
+	return nil
+}

--- a/pkg/controllers/cassandra/actions/scaleout_test.go
+++ b/pkg/controllers/cassandra/actions/scaleout_test.go
@@ -1,0 +1,213 @@
+package actions_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jetstack/navigator/internal/test/unit/framework"
+	"github.com/jetstack/navigator/internal/test/util/generate"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/actions"
+	"github.com/jetstack/navigator/pkg/util/ptr"
+)
+
+func TestScaleOut(t *testing.T) {
+	type testT struct {
+		kubeObjects         []runtime.Object
+		navObjects          []runtime.Object
+		cluster             generate.CassandraClusterConfig
+		nodePool            generate.CassandraClusterNodePoolConfig
+		expectedStatefulSet *generate.StatefulSetConfig
+		expectedErr         bool
+		mutator             func(*framework.StateFixture)
+	}
+	tests := map[string]testT{
+		"Error if StatefulSet not listed": {
+			cluster: generate.CassandraClusterConfig{
+				Name:      "cluster1",
+				Namespace: "ns1",
+			},
+			nodePool: generate.CassandraClusterNodePoolConfig{
+				Name:     "pool1",
+				Replicas: 123,
+			},
+			expectedErr: true,
+		},
+		"Error if clientset.Update fails (e.g. listed but not found)": {
+			kubeObjects: []runtime.Object{
+				generate.StatefulSet(
+					generate.StatefulSetConfig{
+						Name:      "cass-cluster1-pool1",
+						Namespace: "ns1",
+						Replicas:  ptr.Int32(122),
+					},
+				),
+			},
+			cluster: generate.CassandraClusterConfig{
+				Name:      "cluster1",
+				Namespace: "ns1",
+			},
+			nodePool: generate.CassandraClusterNodePoolConfig{
+				Name:     "pool1",
+				Replicas: 123,
+			},
+			expectedErr: true,
+			mutator: func(f *framework.StateFixture) {
+				err := f.KubeClient().
+					AppsV1beta1().
+					StatefulSets("ns1").
+					Delete("cass-cluster1-pool1", &metav1.DeleteOptions{})
+				if err != nil {
+					f.T.Fatal(err)
+				}
+			},
+		},
+		"No update if desired ReplicaCount is lower than actual ReplicaCount": {
+			kubeObjects: []runtime.Object{
+				generate.StatefulSet(
+					generate.StatefulSetConfig{
+						Name:      "cass-cluster1-pool1",
+						Namespace: "ns1",
+						Replicas:  ptr.Int32(124),
+					},
+				),
+			},
+			cluster: generate.CassandraClusterConfig{
+				Name:      "cluster1",
+				Namespace: "ns1",
+			},
+			nodePool: generate.CassandraClusterNodePoolConfig{
+				Name:     "pool1",
+				Replicas: 123,
+			},
+			expectedStatefulSet: &generate.StatefulSetConfig{
+				Name:      "cass-cluster1-pool1",
+				Namespace: "ns1",
+				Replicas:  ptr.Int32(124),
+			},
+			expectedErr: false,
+		},
+		"Idempotent: No error if ReplicaCount already matches the actual ReplicaCount": {
+			kubeObjects: []runtime.Object{
+				generate.StatefulSet(
+					generate.StatefulSetConfig{
+						Name:      "cass-cluster1-pool1",
+						Namespace: "ns1",
+						Replicas:  ptr.Int32(124),
+					},
+				),
+			},
+			cluster: generate.CassandraClusterConfig{
+				Name:      "cluster1",
+				Namespace: "ns1",
+			},
+			nodePool: generate.CassandraClusterNodePoolConfig{
+				Name:     "pool1",
+				Replicas: 124,
+			},
+			expectedStatefulSet: &generate.StatefulSetConfig{
+				Name:      "cass-cluster1-pool1",
+				Namespace: "ns1",
+				Replicas:  ptr.Int32(124),
+			},
+			expectedErr: false,
+		},
+		"The replicas count is incremented": {
+			kubeObjects: []runtime.Object{
+				generate.StatefulSet(
+					generate.StatefulSetConfig{
+						Name:      "cass-cluster1-pool1",
+						Namespace: "ns1",
+						Replicas:  ptr.Int32(122),
+					},
+				),
+			},
+			cluster: generate.CassandraClusterConfig{
+				Name:      "cluster1",
+				Namespace: "ns1",
+			},
+			nodePool: generate.CassandraClusterNodePoolConfig{
+				Name:     "pool1",
+				Replicas: 123,
+			},
+			expectedStatefulSet: &generate.StatefulSetConfig{
+				Name:      "cass-cluster1-pool1",
+				Namespace: "ns1",
+				Replicas:  ptr.Int32(123),
+			},
+		},
+		"The replicas count is only incremented by 1": {
+			kubeObjects: []runtime.Object{
+				generate.StatefulSet(
+					generate.StatefulSetConfig{
+						Name:      "cass-cluster1-pool1",
+						Namespace: "ns1",
+						Replicas:  ptr.Int32(2),
+					},
+				),
+			},
+			cluster: generate.CassandraClusterConfig{
+				Name:      "cluster1",
+				Namespace: "ns1",
+			},
+			nodePool: generate.CassandraClusterNodePoolConfig{
+				Name:     "pool1",
+				Replicas: 4,
+			},
+			expectedStatefulSet: &generate.StatefulSetConfig{
+				Name:      "cass-cluster1-pool1",
+				Namespace: "ns1",
+				Replicas:  ptr.Int32(3),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(
+			name,
+			func(t *testing.T) {
+				fixture := &framework.StateFixture{
+					T:                t,
+					KubeObjects:      test.kubeObjects,
+					NavigatorObjects: test.navObjects,
+				}
+				fixture.Start()
+				defer fixture.Stop()
+				state := fixture.State()
+				if test.mutator != nil {
+					test.mutator(fixture)
+				}
+				a := &actions.ScaleOut{
+					Cluster:  generate.CassandraCluster(test.cluster),
+					NodePool: generate.CassandraClusterNodePool(test.nodePool),
+				}
+				err := a.Execute(state)
+				if err != nil {
+					t.Logf("The error returned by Execute was: %s", err)
+				}
+				if !test.expectedErr && err != nil {
+					t.Errorf("Unexpected error: %s", err)
+				}
+				if test.expectedErr && err == nil {
+					t.Errorf("Expected an error")
+				}
+				if test.expectedStatefulSet != nil {
+					actualStatefulSet, err := fixture.KubeClient().
+						AppsV1beta1().
+						StatefulSets(test.expectedStatefulSet.Namespace).
+						Get(test.expectedStatefulSet.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Fatalf("Unexpected error retrieving statefulset: %v", err)
+					}
+					if *test.expectedStatefulSet.Replicas != *actualStatefulSet.Spec.Replicas {
+						t.Errorf(
+							"Unexpected replica count. Expected: %d. Actual: %d",
+							test.expectedStatefulSet.Replicas, actualStatefulSet.Spec.Replicas,
+						)
+					}
+				}
+			},
+		)
+	}
+}

--- a/pkg/controllers/cassandra/cassandra.go
+++ b/pkg/controllers/cassandra/cassandra.go
@@ -152,6 +152,11 @@ func NewCassandra(
 			recorder,
 		),
 		recorder,
+		&controllers.State{
+			Clientset:         kubeClient,
+			StatefulSetLister: statefulSets.Lister(),
+			Recorder:          recorder,
+		},
 	)
 	cc.recorder = recorder
 	return cc

--- a/pkg/controllers/cassandra/cluster_control.go
+++ b/pkg/controllers/cassandra/cluster_control.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/role"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/rolebinding"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/seedlabeller"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/service"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/serviceaccount"
 )
 
@@ -37,8 +38,8 @@ type ControlInterface interface {
 var _ ControlInterface = &defaultCassandraClusterControl{}
 
 type defaultCassandraClusterControl struct {
-	seedProviderServiceControl ControlInterface
-	nodesServiceControl        ControlInterface
+	seedProviderServiceControl service.Interface
+	nodesServiceControl        service.Interface
 	nodepoolControl            nodepool.Interface
 	pilotControl               pilot.Interface
 	serviceAccountControl      serviceaccount.Interface
@@ -49,8 +50,8 @@ type defaultCassandraClusterControl struct {
 }
 
 func NewControl(
-	seedProviderServiceControl ControlInterface,
-	nodesServiceControl ControlInterface,
+	seedProviderServiceControl service.Interface,
+	nodesServiceControl service.Interface,
 	nodepoolControl nodepool.Interface,
 	pilotControl pilot.Interface,
 	serviceAccountControl serviceaccount.Interface,

--- a/pkg/controllers/cassandra/cluster_control_test.go
+++ b/pkg/controllers/cassandra/cluster_control_test.go
@@ -1,0 +1,92 @@
+package cassandra_test
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/quick"
+
+	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/actions"
+	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
+)
+
+func CassandraClusterSummary(c *v1alpha1.CassandraCluster) string {
+	return fmt.Sprintf(
+		"%s/%s {Spec: %s, Status: %s}",
+		c.Namespace, c.Name,
+		CassandraClusterSpecSummary(c),
+		CassandraClusterStatusSummary(c),
+	)
+}
+
+func CassandraClusterSpecSummary(c *v1alpha1.CassandraCluster) string {
+	nodepools := make([]string, len(c.Spec.NodePools))
+	for i, np := range c.Spec.NodePools {
+		nodepools[i] = fmt.Sprintf("%s:%d", np.Name, np.Replicas)
+	}
+	return fmt.Sprintf(
+		"{nodepools: %s}",
+		strings.Join(nodepools, ", "),
+	)
+}
+
+func CassandraClusterStatusSummary(c *v1alpha1.CassandraCluster) string {
+	nodepools := make([]string, len(c.Status.NodePools))
+	i := 0
+	for title, nps := range c.Status.NodePools {
+		nodepools[i] = fmt.Sprintf("%s:%d", title, nps.ReadyReplicas)
+		i++
+	}
+	return fmt.Sprintf(
+		"{nodepools: %s}", strings.Join(nodepools, ", "),
+	)
+}
+
+func TestNextAction(t *testing.T) {
+	f := func(c *v1alpha1.CassandraCluster) bool {
+		t.Log(CassandraClusterSummary(c))
+		a := cassandra.NextAction(c)
+		if a != nil {
+			t.Log("Action:", a.Name())
+		} else {
+			t.Log("No action")
+		}
+		switch action := a.(type) {
+		case *actions.CreateNodePool:
+			_, found := c.Status.NodePools[action.NodePool.Name]
+			if found {
+				t.Errorf("Unexpected attempt to create a nodepool when there's an existing status")
+				return false
+			}
+		case *actions.ScaleOut:
+			nps, found := c.Status.NodePools[action.NodePool.Name]
+			if !found {
+				t.Errorf("Unexpected attempt to scale up a nodepool without a status")
+				return false
+			}
+			if action.NodePool.Replicas <= nps.ReadyReplicas {
+				t.Errorf("Unexpected attempt to scale up a nodepool with >= ready replicas")
+				return false
+			}
+		}
+		return true
+	}
+	config := &quick.Config{
+		MaxCount: 100,
+		Values: func(values []reflect.Value, rnd *rand.Rand) {
+			cluster := &v1alpha1.CassandraCluster{}
+			cluster.SetName("cluster1")
+			cluster.SetNamespace("ns1")
+			casstesting.FuzzCassandraClusterNodePools(cluster, rnd, 0)
+			values[0] = reflect.ValueOf(cluster)
+		},
+	}
+	err := quick.Check(f, config)
+	if err != nil {
+		t.Errorf("quick check failure: %#v", err)
+	}
+}

--- a/pkg/controllers/cassandra/nodepool/nodepool_test.go
+++ b/pkg/controllers/cassandra/nodepool/nodepool_test.go
@@ -3,7 +3,6 @@ package nodepool_test
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/jetstack/navigator/internal/test/unit/framework"
@@ -34,33 +33,6 @@ func TestNodePoolControlSync(t *testing.T) {
 	}
 
 	tests := map[string]testT{
-		"create object if not exists": {
-			cluster: cluster1.DeepCopy(),
-			assertions: func(t *testing.T, state *controllers.State, test testT) {
-				expectedObject := set1
-				_, err := state.Clientset.AppsV1beta1().
-					StatefulSets(expectedObject.Namespace).
-					Get(expectedObject.Name, v1.GetOptions{})
-				if err != nil {
-					t.Error(err)
-				}
-			},
-		},
-
-		"no error if object already exists": {
-			kubeObjects: []runtime.Object{set1},
-			cluster:     cluster1.DeepCopy(),
-		},
-		"no error if object not yet listed": {
-			kubeObjects: []runtime.Object{},
-			cluster:     cluster1.DeepCopy(),
-			fixtureManipulator: func(t *testing.T, fixture *framework.StateFixture) {
-				_, err := fixture.KubeClient().AppsV1beta1().StatefulSets(set1.Namespace).Create(set1)
-				if err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
 		"add nodepool status if a matching statefulset exists": {
 			kubeObjects: []runtime.Object{set1},
 			cluster:     cluster1.DeepCopy(),

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -34,7 +34,6 @@ func StatefulSetForCluster(
 	cluster *v1alpha1.CassandraCluster,
 	np *v1alpha1.CassandraClusterNodePool,
 ) *apps.StatefulSet {
-
 	statefulSetName := util.NodePoolResourceName(cluster, np)
 	nodePoolLabels := util.NodePoolLabels(cluster, np.Name)
 
@@ -49,7 +48,7 @@ func StatefulSetForCluster(
 			OwnerReferences: []metav1.OwnerReference{util.NewControllerRef(cluster)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: ptr.Int32(np.Replicas),
+			Replicas: ptr.Int32(0),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: nodePoolLabels,
 			},
@@ -303,6 +302,7 @@ func StatefulSetForCluster(
 			},
 		)
 	}
+
 	return set
 }
 

--- a/pkg/controllers/cassandra/service/control.go
+++ b/pkg/controllers/cassandra/service/control.go
@@ -24,6 +24,10 @@ const (
 
 type serviceFactory func(*v1alpha1.CassandraCluster) *apiv1.Service
 
+type Interface interface {
+	Sync(*v1alpha1.CassandraCluster) error
+}
+
 type control struct {
 	kubeClient     kubernetes.Interface
 	serviceLister  corelisters.ServiceLister
@@ -31,12 +35,14 @@ type control struct {
 	serviceFactory serviceFactory
 }
 
+var _ Interface = &control{}
+
 func NewControl(
 	kubeClient kubernetes.Interface,
 	serviceLister corelisters.ServiceLister,
 	recorder record.EventRecorder,
 	serviceFactory serviceFactory,
-) *control {
+) Interface {
 	return &control{
 		kubeClient:     kubeClient,
 		serviceLister:  serviceLister,

--- a/pkg/controllers/cassandra/testing/gen.go
+++ b/pkg/controllers/cassandra/testing/gen.go
@@ -1,0 +1,46 @@
+package testing
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+)
+
+func FuzzCassandraNodePool(np *v1alpha1.CassandraClusterNodePool, rand *rand.Rand, size int) {
+	np.Replicas = rand.Int31n(5)
+}
+
+func FuzzCassandraClusterNodePools(cluster *v1alpha1.CassandraCluster, rand *rand.Rand, size int) {
+	if cluster.Spec.NodePools == nil {
+		cluster.Spec.NodePools = []v1alpha1.CassandraClusterNodePool{}
+	}
+	if cluster.Status.NodePools == nil {
+		cluster.Status.NodePools = map[string]v1alpha1.CassandraClusterNodePoolStatus{}
+	}
+	for i := 0; i < rand.Intn(5); i++ {
+		np := v1alpha1.CassandraClusterNodePool{
+			Name: fmt.Sprintf("np%d", i),
+		}
+		FuzzCassandraNodePool(&np, rand, size)
+		nps := v1alpha1.CassandraClusterNodePoolStatus{
+			ReadyReplicas: np.Replicas,
+		}
+		// 20% chance of ScaleOut
+		if rand.Intn(4) == 0 {
+			np.Replicas++
+		}
+		// 20% chance of ScaleIn
+		if rand.Intn(4) == 0 {
+			nps.ReadyReplicas++
+		}
+		// 20% chance of a NodePool removal
+		if rand.Intn(4) != 0 {
+			cluster.Spec.NodePools = append(cluster.Spec.NodePools, np)
+		}
+		// 20% chance of a NodePool create
+		if rand.Intn(4) != 0 {
+			cluster.Status.NodePools[np.Name] = nps
+		}
+	}
+}

--- a/pkg/controllers/cassandra/testing/testing.go
+++ b/pkg/controllers/cassandra/testing/testing.go
@@ -6,6 +6,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1beta1"
 
 	navinformers "github.com/jetstack/navigator/pkg/client/informers/externalversions"
+	"github.com/jetstack/navigator/pkg/controllers"
 
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra"
@@ -178,6 +179,11 @@ func (f *Fixture) setupAndSync() error {
 		f.RoleBindingControl,
 		f.SeedLabellerControl,
 		recorder,
+		&controllers.State{
+			Clientset:         f.k8sClient,
+			StatefulSetLister: statefulSets,
+			Recorder:          recorder,
+		},
 	)
 	stopCh := make(chan struct{})
 	defer close(stopCh)


### PR DESCRIPTION
These become the only changes supported by the Cassandra controller until ScaleIn and  CassandraUpgrade actions are implemented in followup branches.

Fixes: #253 

**Release note**:
```release-note
NONE
```
