### PR TITLE
Move rack and datacenter defaulting to API

### DIFF
--- a/pkg/apis/navigator/v1alpha1/defaults.go
+++ b/pkg/apis/navigator/v1alpha1/defaults.go
@@ -4,6 +4,23 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	cassDefaultDatacenter = "navigator-default-datacenter"
+)
+
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
+}
+
+func SetDefaults_CassandraClusterSpec(spec *CassandraClusterSpec) {
+	for i := 0; i < len(spec.NodePools); i++ {
+		np := &spec.NodePools[i]
+		if np.Datacenter == "" {
+			np.Datacenter = cassDefaultDatacenter
+		}
+
+		if np.Rack == "" {
+			np.Rack = np.Name
+		}
+	}
 }

--- a/pkg/apis/navigator/v1alpha1/defaults.go
+++ b/pkg/apis/navigator/v1alpha1/defaults.go
@@ -12,15 +12,12 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-func SetDefaults_CassandraClusterSpec(spec *CassandraClusterSpec) {
-	for i := 0; i < len(spec.NodePools); i++ {
-		np := &spec.NodePools[i]
-		if np.Datacenter == "" {
-			np.Datacenter = cassDefaultDatacenter
-		}
+func SetDefaults_CassandraClusterNodePool(np *CassandraClusterNodePool) {
+	if np.Datacenter == "" {
+		np.Datacenter = cassDefaultDatacenter
+	}
 
-		if np.Rack == "" {
-			np.Rack = np.Name
-		}
+	if np.Rack == "" {
+		np.Rack = np.Name
 	}
 }

--- a/pkg/apis/navigator/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.defaults.go
@@ -28,5 +28,18 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&CassandraCluster{}, func(obj interface{}) { SetObjectDefaults_CassandraCluster(obj.(*CassandraCluster)) })
+	scheme.AddTypeDefaultingFunc(&CassandraClusterList{}, func(obj interface{}) { SetObjectDefaults_CassandraClusterList(obj.(*CassandraClusterList)) })
 	return nil
+}
+
+func SetObjectDefaults_CassandraCluster(in *CassandraCluster) {
+	SetDefaults_CassandraClusterSpec(&in.Spec)
+}
+
+func SetObjectDefaults_CassandraClusterList(in *CassandraClusterList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_CassandraCluster(a)
+	}
 }

--- a/pkg/apis/navigator/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.defaults.go
@@ -34,7 +34,10 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_CassandraCluster(in *CassandraCluster) {
-	SetDefaults_CassandraClusterSpec(&in.Spec)
+	for i := range in.Spec.NodePools {
+		a := &in.Spec.NodePools[i]
+		SetDefaults_CassandraClusterNodePool(a)
+	}
 }
 
 func SetObjectDefaults_CassandraClusterList(in *CassandraClusterList) {

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -23,8 +23,6 @@ const (
 
 	cassSnitch = "GossipingPropertyFileSnitch"
 
-	cassDefaultDatacenter = "navigator-default-datacenter"
-
 	// See https://jolokia.org/reference/html/agents.html#jvm-agent
 	jolokiaHost    = "127.0.0.1"
 	jolokiaPort    = 8778
@@ -39,16 +37,9 @@ func StatefulSetForCluster(
 	statefulSetName := util.NodePoolResourceName(cluster, np)
 	seedProviderServiceName := util.SeedProviderServiceName(cluster)
 	nodePoolLabels := util.NodePoolLabels(cluster, np.Name)
-	datacenter := cassDefaultDatacenter
-	if np.Datacenter != "" {
-		datacenter = np.Datacenter
-	}
 
-	rack := np.Name
-	if np.Rack != "" {
-		rack = np.Rack
-	}
 	image := cassImageToUse(&cluster.Spec)
+
 	set := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            statefulSetName,
@@ -217,11 +208,11 @@ func StatefulSetForCluster(
 								},
 								{
 									Name:  "CASSANDRA_DC",
-									Value: datacenter,
+									Value: np.Datacenter,
 								},
 								{
 									Name:  "CASSANDRA_RACK",
-									Value: rack,
+									Value: np.Rack,
 								},
 								{
 									Name: "JVM_OPTS",

--- a/pkg/registry/navigator/cassandracluster/strategy.go
+++ b/pkg/registry/navigator/cassandracluster/strategy.go
@@ -30,10 +30,6 @@ import (
 	"github.com/jetstack/navigator/pkg/apis/navigator/validation"
 )
 
-const (
-	cassDefaultDatacenter = "navigator-default-datacenter"
-)
-
 func NewStrategy(typer runtime.ObjectTyper) cassandraClusterStrategy {
 	return cassandraClusterStrategy{typer, names.SimpleNameGenerator}
 }
@@ -70,27 +66,10 @@ func (cassandraClusterStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func defaultRackDatacenter(new *navigator.CassandraCluster) {
-	for i := 0; i < len(new.Spec.NodePools); i++ {
-		np := &new.Spec.NodePools[i]
-		if np.Datacenter == "" {
-			np.Datacenter = cassDefaultDatacenter
-		}
-
-		if np.Rack == "" {
-			np.Rack = np.Name
-		}
-	}
-}
-
 func (cassandraClusterStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
-	new := obj.(*navigator.CassandraCluster)
-	defaultRackDatacenter(new)
 }
 
 func (cassandraClusterStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runtime.Object) {
-	new := obj.(*navigator.CassandraCluster)
-	defaultRackDatacenter(new)
 }
 
 func (cassandraClusterStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/navigator/cassandracluster/strategy.go
+++ b/pkg/registry/navigator/cassandracluster/strategy.go
@@ -30,6 +30,10 @@ import (
 	"github.com/jetstack/navigator/pkg/apis/navigator/validation"
 )
 
+const (
+	cassDefaultDatacenter = "navigator-default-datacenter"
+)
+
 func NewStrategy(typer runtime.ObjectTyper) cassandraClusterStrategy {
 	return cassandraClusterStrategy{typer, names.SimpleNameGenerator}
 }
@@ -66,10 +70,27 @@ func (cassandraClusterStrategy) NamespaceScoped() bool {
 	return true
 }
 
+func defaultRackDatacenter(new *navigator.CassandraCluster) {
+	for i := 0; i < len(new.Spec.NodePools); i++ {
+		np := &new.Spec.NodePools[i]
+		if np.Datacenter == "" {
+			np.Datacenter = cassDefaultDatacenter
+		}
+
+		if np.Rack == "" {
+			np.Rack = np.Name
+		}
+	}
+}
+
 func (cassandraClusterStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
+	new := obj.(*navigator.CassandraCluster)
+	defaultRackDatacenter(new)
 }
 
 func (cassandraClusterStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runtime.Object) {
+	new := obj.(*navigator.CassandraCluster)
+	defaultRackDatacenter(new)
 }
 
 func (cassandraClusterStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {


### PR DESCRIPTION
This allows the defaults to be visable in something like `kubectl get
cassandraclusters`, avoiding the user being surprised.

```release-note
NONE
```
