### PR TITLE
Move seed pod labelling to a separate controller

### DIFF
--- a/pkg/controllers/cassandra/cassandra.go
+++ b/pkg/controllers/cassandra/cassandra.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/pilot"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/role"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/rolebinding"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/seedlabeller"
 	servicecql "github.com/jetstack/navigator/pkg/controllers/cassandra/service/cql"
 	serviceseedprovider "github.com/jetstack/navigator/pkg/controllers/cassandra/service/seedprovider"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/serviceaccount"
@@ -110,7 +111,6 @@ func NewCassandra(
 		nodepool.NewControl(
 			kubeClient,
 			statefulSets.Lister(),
-			pods.Lister(),
 			recorder,
 		),
 		pilot.NewControl(
@@ -133,6 +133,12 @@ func NewCassandra(
 		rolebinding.NewControl(
 			kubeClient,
 			roleBindings.Lister(),
+			recorder,
+		),
+		seedlabeller.NewControl(
+			kubeClient,
+			statefulSets.Lister(),
+			pods.Lister(),
 			recorder,
 		),
 		recorder,

--- a/pkg/controllers/cassandra/nodepool/nodepool.go
+++ b/pkg/controllers/cassandra/nodepool/nodepool.go
@@ -1,14 +1,9 @@
 package nodepool
 
 import (
-	"fmt"
-
-	"github.com/golang/glog"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1beta1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
@@ -22,7 +17,6 @@ type Interface interface {
 type defaultCassandraClusterNodepoolControl struct {
 	kubeClient        kubernetes.Interface
 	statefulSetLister appslisters.StatefulSetLister
-	pods              corelisters.PodLister
 	recorder          record.EventRecorder
 }
 
@@ -31,13 +25,11 @@ var _ Interface = &defaultCassandraClusterNodepoolControl{}
 func NewControl(
 	kubeClient kubernetes.Interface,
 	statefulSetLister appslisters.StatefulSetLister,
-	pods corelisters.PodLister,
 	recorder record.EventRecorder,
 ) Interface {
 	return &defaultCassandraClusterNodepoolControl{
 		kubeClient:        kubeClient,
 		statefulSetLister: statefulSetLister,
-		pods:              pods,
 		recorder:          recorder,
 	}
 }
@@ -76,30 +68,6 @@ func (e *defaultCassandraClusterNodepoolControl) removeUnusedStatefulSets(
 	return nil
 }
 
-func (e *defaultCassandraClusterNodepoolControl) labelSeedNodes(
-	cluster *v1alpha1.CassandraCluster,
-	set *appsv1beta1.StatefulSet,
-) error {
-	// TODO: make number of seed nodes configurable
-	pod, err := e.pods.Pods(cluster.Namespace).Get(fmt.Sprintf("%s-%d", set.Name, 0))
-	if err != nil {
-		glog.Warningf("Couldn't get stateful set pod: %v", err)
-		return nil
-	}
-
-	// only label if the current label is incorrect
-	if pod.Labels["seed"] != "true" {
-		podCopy := pod.DeepCopy()
-		podCopy.Labels["seed"] = "true"
-		_, err := e.kubeClient.CoreV1().Pods(podCopy.Namespace).Update(podCopy)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (e *defaultCassandraClusterNodepoolControl) createOrUpdateStatefulSet(
 	cluster *v1alpha1.CassandraCluster,
 	nodePool *v1alpha1.CassandraClusterNodePool,
@@ -116,11 +84,6 @@ func (e *defaultCassandraClusterNodepoolControl) createOrUpdateStatefulSet(
 		return err
 	}
 	err = util.OwnerCheck(existingSet, cluster)
-	if err != nil {
-		return err
-	}
-
-	err = e.labelSeedNodes(cluster, existingSet)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/cassandra/seedlabeller/control.go
+++ b/pkg/controllers/cassandra/seedlabeller/control.go
@@ -1,0 +1,82 @@
+package seedlabeller
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	"k8s.io/client-go/kubernetes"
+	appslisters "k8s.io/client-go/listers/apps/v1beta1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/service/seedprovider"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+)
+
+type Interface interface {
+	Sync(*v1alpha1.CassandraCluster) error
+}
+
+type defaultSeedLabeller struct {
+	kubeClient        kubernetes.Interface
+	statefulSetLister appslisters.StatefulSetLister
+	pods              corelisters.PodLister
+	recorder          record.EventRecorder
+}
+
+var _ Interface = &defaultSeedLabeller{}
+
+func NewControl(
+	kubeClient kubernetes.Interface,
+	statefulSetLister appslisters.StatefulSetLister,
+	pods corelisters.PodLister,
+	recorder record.EventRecorder,
+) Interface {
+	return &defaultSeedLabeller{
+		kubeClient:        kubeClient,
+		statefulSetLister: statefulSetLister,
+		pods:              pods,
+		recorder:          recorder,
+	}
+}
+
+func (c *defaultSeedLabeller) labelSeedNodes(
+	cluster *v1alpha1.CassandraCluster,
+	set *appsv1beta1.StatefulSet,
+) error {
+	// TODO: make number of seed nodes configurable
+	pod, err := c.pods.Pods(cluster.Namespace).Get(fmt.Sprintf("%s-%d", set.Name, 0))
+	if err != nil {
+		glog.Warningf("Couldn't get stateful set pod: %v", err)
+		return nil
+	}
+	labels := pod.Labels
+	value := labels[seedprovider.SeedLabelKey]
+	if value == seedprovider.SeedLabelValue {
+		return nil
+	}
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[seedprovider.SeedLabelKey] = seedprovider.SeedLabelValue
+	podCopy := pod.DeepCopy()
+	podCopy.SetLabels(labels)
+	_, err = c.kubeClient.CoreV1().Pods(podCopy.Namespace).Update(podCopy)
+	return err
+}
+
+func (c *defaultSeedLabeller) Sync(cluster *v1alpha1.CassandraCluster) error {
+	sets, err := util.StatefulSetsForCluster(cluster, c.statefulSetLister)
+	if err != nil {
+		return err
+	}
+	for _, s := range sets {
+		err = c.labelSeedNodes(cluster, s)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controllers/cassandra/seedlabeller/control_test.go
+++ b/pkg/controllers/cassandra/seedlabeller/control_test.go
@@ -1,0 +1,120 @@
+package seedlabeller_test
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jetstack/navigator/internal/test/unit/framework"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/nodepool"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/seedlabeller"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/service/seedprovider"
+	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
+)
+
+func CheckSeedLabel(podName, podNamespace string, t *testing.T, state *controllers.State) {
+	p, err := state.Clientset.
+		CoreV1().
+		Pods(podNamespace).
+		Get(podName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Labels[seedprovider.SeedLabelKey] != seedprovider.SeedLabelValue {
+		t.Errorf("unexpected seed label: %s", p.Labels)
+	}
+}
+
+func TestSeedLabellerSync(t *testing.T) {
+	cluster := casstesting.ClusterForTest()
+	np0 := &cluster.Spec.NodePools[0]
+	ss0 := nodepool.StatefulSetForCluster(cluster, np0)
+	pod0 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cass-cassandra-1-RingNodes-0",
+			Namespace: cluster.Namespace,
+		},
+	}
+	pod0LabelMissing := pod0.DeepCopy()
+	pod0LabelMissing.SetLabels(map[string]string{})
+	pod0ValueIncorrect := pod0LabelMissing.DeepCopy()
+	pod0ValueIncorrect.Labels[seedprovider.SeedLabelKey] = "blah"
+
+	type testT struct {
+		kubeObjects []runtime.Object
+		navObjects  []runtime.Object
+		cluster     *v1alpha1.CassandraCluster
+		assertions  func(*testing.T, *controllers.State)
+		expectErr   bool
+	}
+
+	tests := map[string]testT{
+		"ignore missing pod": {
+			kubeObjects: []runtime.Object{ss0},
+			navObjects:  []runtime.Object{cluster},
+			cluster:     cluster,
+		},
+		"add label if nil labels": {
+			kubeObjects: []runtime.Object{ss0, pod0},
+			navObjects:  []runtime.Object{cluster},
+			cluster:     cluster,
+			assertions: func(t *testing.T, state *controllers.State) {
+				CheckSeedLabel(pod0.Name, pod0.Namespace, t, state)
+			},
+		},
+		"add label if key missing": {
+			kubeObjects: []runtime.Object{ss0, pod0LabelMissing},
+			navObjects:  []runtime.Object{cluster},
+			cluster:     cluster,
+			assertions: func(t *testing.T, state *controllers.State) {
+				CheckSeedLabel(pod0.Name, pod0.Namespace, t, state)
+			},
+		},
+		"fix label if value incorrect": {
+			kubeObjects: []runtime.Object{ss0, pod0ValueIncorrect},
+			navObjects:  []runtime.Object{cluster},
+			cluster:     cluster,
+			assertions: func(t *testing.T, state *controllers.State) {
+				CheckSeedLabel(pod0.Name, pod0.Namespace, t, state)
+			},
+		},
+	}
+	for title, test := range tests {
+		t.Run(
+			title,
+			func(t *testing.T) {
+				fixture := &framework.StateFixture{
+					T:                t,
+					KubeObjects:      test.kubeObjects,
+					NavigatorObjects: test.navObjects,
+				}
+				fixture.Start()
+				defer fixture.Stop()
+				state := fixture.State()
+				c := seedlabeller.NewControl(
+					state.Clientset,
+					state.StatefulSetLister,
+					state.PodLister,
+					state.Recorder,
+				)
+				err := c.Sync(test.cluster)
+				if err != nil {
+					if !test.expectErr {
+						t.Errorf("Unexpected error: %s", err)
+					}
+				} else {
+					if test.expectErr {
+						t.Error("Missing error")
+					}
+				}
+				if test.assertions != nil {
+					test.assertions(t, state)
+				}
+			},
+		)
+	}
+}

--- a/pkg/controllers/cassandra/service/seedprovider/resource.go
+++ b/pkg/controllers/cassandra/service/seedprovider/resource.go
@@ -10,6 +10,8 @@ import (
 
 const (
 	TolerateUnreadyEndpointsAnnotationKey = "service.alpha.kubernetes.io/tolerate-unready-endpoints"
+	SeedLabelKey                          = "navigator.jetstack.io/cassandra-seed"
+	SeedLabelValue                        = "true"
 )
 
 func ServiceForCluster(
@@ -29,7 +31,7 @@ func updateServiceForCluster(
 	service.Spec.ClusterIP = "None"
 
 	// Only mark nodes explicitly labeled as seeds as seed nodes
-	service.Spec.Selector["seed"] = "true"
+	service.Spec.Selector[SeedLabelKey] = SeedLabelValue
 
 	// Headless service should not require a port.
 	// But without it, DNS records are not registered.

--- a/pkg/controllers/cassandra/testing/testing.go
+++ b/pkg/controllers/cassandra/testing/testing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/pilot"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/role"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/rolebinding"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/seedlabeller"
 	servicecql "github.com/jetstack/navigator/pkg/controllers/cassandra/service/cql"
 	serviceseedprovider "github.com/jetstack/navigator/pkg/controllers/cassandra/service/seedprovider"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/serviceaccount"
@@ -57,6 +58,7 @@ type Fixture struct {
 	ServiceAccountControl      serviceaccount.Interface
 	RoleControl                role.Interface
 	RoleBindingControl         rolebinding.Interface
+	SeedLabellerControl        seedlabeller.Interface
 	k8sClient                  *fake.Clientset
 	k8sObjects                 []runtime.Object
 	naviClient                 *navigatorfake.Clientset
@@ -108,7 +110,6 @@ func (f *Fixture) setupAndSync() error {
 		f.NodepoolControl = nodepool.NewControl(
 			f.k8sClient,
 			statefulSets,
-			pods,
 			recorder,
 		)
 	}
@@ -151,6 +152,15 @@ func (f *Fixture) setupAndSync() error {
 		)
 	}
 
+	if f.SeedLabellerControl == nil {
+		f.SeedLabellerControl = seedlabeller.NewControl(
+			f.k8sClient,
+			statefulSets,
+			pods,
+			recorder,
+		)
+	}
+
 	c := cassandra.NewControl(
 		f.SeedProviderServiceControl,
 		f.CqlServiceControl,
@@ -159,6 +169,7 @@ func (f *Fixture) setupAndSync() error {
 		f.ServiceAccountControl,
 		f.RoleControl,
 		f.RoleBindingControl,
+		f.SeedLabellerControl,
 		recorder,
 	)
 	stopCh := make(chan struct{})


### PR DESCRIPTION
* In #256 I want to refactor nodepool.Sync so that its only responsibility is to update the NodePool status.
* And the seed labelling seems like it is a separate concern that can live in its own module.
* With its own unit tests.

**Release note**:
```release-note
NONE
```
