### PR TITLE
Run jmx_exporter on cassandra nodes to expose metrics

### DIFF
--- a/Dockerfile.pilot-cassandra
+++ b/Dockerfile.pilot-cassandra
@@ -1,7 +1,10 @@
 FROM alpine:3.6
 
 ADD http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.4.0/jolokia-jvm-1.4.0-agent.jar /jolokia.jar
+ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar /jmx_prometheus_javaagent.jar
+
 RUN chmod a+r /jolokia.jar && touch /jolokia.jar
+RUN chmod a+r /jmx_prometheus_javaagent.jar && touch /jmx_prometheus_javaagent.jar
 
 # note: temporarily pulled directly from kubernetes/examples until we find a better place to put it
 ADD https://github.com/kubernetes/examples/raw/master/cassandra/image/files/kubernetes-cassandra.jar /kubernetes-cassandra.jar

--- a/Dockerfile.pilot-cassandra
+++ b/Dockerfile.pilot-cassandra
@@ -2,9 +2,11 @@ FROM alpine:3.6
 
 ADD http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.4.0/jolokia-jvm-1.4.0-agent.jar /jolokia.jar
 ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar /jmx_prometheus_javaagent.jar
+ADD https://raw.githubusercontent.com/prometheus/jmx_exporter/master/example_configs/cassandra.yml /jmx_prometheus_javaagent.yaml
 
 RUN chmod a+r /jolokia.jar && touch /jolokia.jar
 RUN chmod a+r /jmx_prometheus_javaagent.jar && touch /jmx_prometheus_javaagent.jar
+RUN chmod a+r /jmx_prometheus_javaagent.yaml && touch /jmx_prometheus_javaagent.yaml
 
 # note: temporarily pulled directly from kubernetes/examples until we find a better place to put it
 ADD https://github.com/kubernetes/examples/raw/master/cassandra/image/files/kubernetes-cassandra.jar /kubernetes-cassandra.jar

--- a/Dockerfile.pilot-cassandra
+++ b/Dockerfile.pilot-cassandra
@@ -2,7 +2,7 @@ FROM alpine:3.6
 
 ADD http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.4.0/jolokia-jvm-1.4.0-agent.jar /jolokia.jar
 ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.0/jmx_prometheus_javaagent-0.3.0.jar /jmx_prometheus_javaagent.jar
-ADD https://raw.githubusercontent.com/prometheus/jmx_exporter/master/example_configs/cassandra.yml /jmx_prometheus_javaagent.yaml
+ADD https://raw.githubusercontent.com/prometheus/jmx_exporter/0b490c14b6a8b53518b63aaaf02bf769e2eada4e/example_configs/cassandra.yml /jmx_prometheus_javaagent.yaml
 
 RUN chmod a+r /jolokia.jar && touch /jolokia.jar
 RUN chmod a+r /jmx_prometheus_javaagent.jar && touch /jmx_prometheus_javaagent.jar

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -231,6 +231,13 @@ function test_cassandracluster() {
         fail_test "Navigator controller failed to create cassandracluster service"
     fi
 
+    if ! retry TIMEOUT=300 in_cluster_command \
+        "${namespace}" \
+        "alpine:3.6" \
+        /bin/sh -c "apk add --no-cache curl && curl -vv http://cass-${CASS_NAME}-ringnodes-0.cass-${CASS_NAME}-seedprovider:8080"; then
+        fail_test "Pilot did not start Prometheus metric exporter"
+    fi
+
     # Create a database
     cql_connect \
         "${namespace}" \

--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -197,19 +197,26 @@ function cql_connect() {
     # XXX: This uses the standard Cassandra Docker image rather than the
     # gcr.io/google-samples/cassandra image used in the Cassandra chart, becasue
     # cqlsh is missing some dependencies in that image.
+    in_cluster_command "${namespace}" "cassandra:latest" /usr/bin/cqlsh "$@"
+}
+
+function in_cluster_command() {
+    local namespace="${1}"
+    shift
+    local image="${1}"
+    shift
     kubectl \
         run \
-        "cql-connect-${RANDOM}" \
+        "in-cluster-${1}-cmd-${RANDOM}" \
         --namespace="${namespace}" \
-        --command=true \
-        --image=cassandra:latest \
+        --image="${image}" \
         --restart=Never \
         --rm \
         --stdin=true \
         --attach=true \
         --quiet \
         -- \
-        /usr/bin/cqlsh "$@"
+        "${@}"
 }
 
 function kill_cassandra_process() {

--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -116,7 +116,7 @@ function simulate_unresponsive_cassandra_process() {
     kubectl \
         --namespace="${namespace}" \
         exec "${pod}" --container="${container}" -- \
-        nodetool decommission
+        /bin/sh -c 'JVM_OPTS="" exec nodetool decommission'
 }
 
 function signal_cassandra_process() {

--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -207,7 +207,7 @@ function in_cluster_command() {
     shift
     kubectl \
         run \
-        "in-cluster-${1}-cmd-${RANDOM}" \
+        "in-cluster-cmd-${RANDOM}" \
         --namespace="${namespace}" \
         --image="${image}" \
         --restart=Never \

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -163,6 +163,10 @@ func StatefulSetForCluster(
 									Name:          "cql",
 									ContainerPort: util.DefaultCqlPort,
 								},
+								{
+									Name:          "prometheus",
+									ContainerPort: int32(8080),
+								},
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
@@ -217,11 +221,13 @@ func StatefulSetForCluster(
 								{
 									Name: "JVM_OPTS",
 									Value: fmt.Sprintf(
-										"-javaagent:%s/jolokia.jar=host=%s,port=%d,agentContext=%s",
+										"-javaagent:%s/jolokia.jar=host=%s,port=%d,agentContext=%s "+
+											"-javaagent:%s/jmx_prometheus_javaagent.jar=8080:config.yaml",
 										sharedVolumeMountPath,
 										jolokiaHost,
 										jolokiaPort,
 										jolokiaContext,
+										sharedVolumeMountPath,
 									),
 								},
 								{
@@ -315,6 +321,7 @@ func pilotInstallationContainer(
 			"cp",
 			"/pilot",
 			"/jolokia.jar",
+			"/jmx_prometheus_javaagent.jar",
 			"/kubernetes-cassandra.jar",
 			fmt.Sprintf("%s/", sharedVolumeMountPath),
 		},

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -222,11 +222,12 @@ func StatefulSetForCluster(
 									Name: "JVM_OPTS",
 									Value: fmt.Sprintf(
 										"-javaagent:%s/jolokia.jar=host=%s,port=%d,agentContext=%s "+
-											"-javaagent:%s/jmx_prometheus_javaagent.jar=8080:config.yaml",
+											"-javaagent:%s/jmx_prometheus_javaagent.jar=8080:%s/jmx_prometheus_javaagent.yaml",
 										sharedVolumeMountPath,
 										jolokiaHost,
 										jolokiaPort,
 										jolokiaContext,
+										sharedVolumeMountPath,
 										sharedVolumeMountPath,
 									),
 								},
@@ -322,6 +323,7 @@ func pilotInstallationContainer(
 			"/pilot",
 			"/jolokia.jar",
 			"/jmx_prometheus_javaagent.jar",
+			"/jmx_prometheus_javaagent.yaml",
 			"/kubernetes-cassandra.jar",
 			fmt.Sprintf("%s/", sharedVolumeMountPath),
 		},

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -61,6 +61,11 @@ func StatefulSetForCluster(
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: nodePoolLabels,
+					Annotations: map[string]string{
+						"prometheus.io/port":   "8080",
+						"prometheus.io/path":   "/",
+						"prometheus.io/scrape": "true",
+					},
 				},
 				Spec: apiv1.PodSpec{
 					ServiceAccountName: util.ServiceAccountName(cluster),


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to gather metrics into Prometheus, this PR enables the JMX exporter on Cassandra nodes.

I've also added a basic e2e test to ensure the prometheus endpoint starts listening on port 8080.

**Release note**:
```release-note
Enable Prometheus JMX exporter on Cassandra nodes
```

/assign @kragniz 
