### PR TITLE
Add shortName for cassandracluster

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -209,8 +209,8 @@ function test_cassandracluster() {
 
     if ! kubectl get \
          --namespace "${namespace}" \
-         cass; then
-         fail_test "Failed to get cassandraclusters short name (cass)"
+         cassandra; then
+         fail_test "Failed to get cassandraclusters short name (cassandra)"
     fi
 
     if ! kubectl apply \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -207,6 +207,12 @@ function test_cassandracluster() {
         fail_test "Failed to get cassandraclusters"
     fi
 
+    if ! kubectl get \
+         --namespace "${namespace}" \
+         cass; then
+         fail_test "Failed to get cassandraclusters short name (cass)"
+    fi
+
     if ! kubectl apply \
         --namespace "${namespace}" \
         --filename \

--- a/pkg/registry/navigator/cassandracluster/etcd.go
+++ b/pkg/registry/navigator/cassandracluster/etcd.go
@@ -47,6 +47,6 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*reg
 
 	return &registry.REST{
 		Store:              &store,
-		ResourceShortNames: []string{},
+		ResourceShortNames: []string{"cass"},
 	}, &registry.REST{Store: &statusStore}, nil
 }

--- a/pkg/registry/navigator/cassandracluster/etcd.go
+++ b/pkg/registry/navigator/cassandracluster/etcd.go
@@ -47,6 +47,6 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*reg
 
 	return &registry.REST{
 		Store:              &store,
-		ResourceShortNames: []string{"cass"},
+		ResourceShortNames: []string{"cassandra"},
 	}, &registry.REST{Store: &statusStore}, nil
 }

--- a/pkg/registry/navigator/escluster/etcd.go
+++ b/pkg/registry/navigator/escluster/etcd.go
@@ -46,6 +46,6 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*reg
 
 	return &registry.REST{
 		Store:              &store,
-		ResourceShortNames: []string{"esc"},
+		ResourceShortNames: []string{"esc", "elasticsearch"},
 	}, &registry.REST{Store: &statusStore}, nil
 }


### PR DESCRIPTION
So commands like `kubectl get cass` are shorter.

```release-note
none
```
