### PR TITLE
Allow Cassandra NodePools to be configured with resource requests and limits.

### DIFF
--- a/contrib/charts/navigator/templates/controller.yaml
+++ b/contrib/charts/navigator/templates/controller.yaml
@@ -36,8 +36,8 @@ spec:
           - navigator-controller
 {{- if .Values.controller.namespace }}
           - --namespace={{ .Values.controller.namespace }}
-          - --leader-election-namespace={{ .Values.controller.namespace }}
 {{- end }}
+          - --leader-election-namespace={{ .Release.Namespace }}
           - --v={{ .Values.controller.logLevel }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           resources:

--- a/contrib/charts/navigator/templates/leaderelection-endpoint.yaml
+++ b/contrib/charts/navigator/templates/leaderelection-endpoint.yaml
@@ -2,9 +2,5 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: navigator-controller
-{{- if .Values.controller.namespace }}
-  namespace: {{ .Values.controller.namespace }}
-{{- else }}
-  namespace: kube-system
-{{- end }}
+  namespace: {{ .Release.Namespace }}
 subsets: []

--- a/docs/cassandra.rst
+++ b/docs/cassandra.rst
@@ -9,6 +9,14 @@ Example ``CassandraCluster`` resource:
 .. include:: quick-start/cassandra-cluster.yaml
    :literal:
 
+Node Pools
+----------
+
+The C* nodes in a Navigator ``cassandracluster`` are configured and grouped by rack and data center
+and in Navigator, these groups of nodes are called ``nodepools``.
+
+All the C* nodes (pods) in a ``nodepool`` have the same configuration and the following sections describe the configuration options that are available:
+
 Cassandra Across Multiple Availability Zones
 --------------------------------------------
 
@@ -96,3 +104,15 @@ A simplified example:
       rack: "default-rack"
       nodeSelector:
         failure-domain.beta.kubernetes.io/zone: "europe-west1-d"
+
+Managing Compute Resources for Cassandra Clusters
+-------------------------------------------------
+
+Each ``nodepool`` has a ``resources`` attribute which defines the resource requirements and limits for each C* node (pod) in the pool.
+
+In the example above, each C* node (pod) in the ``nodepool`` named ``ringnodes`` will request half a CPU core and 2GiB of memory.
+
+The ``resources`` field follows exactly the same specification as the Kubernetes Pod API
+(``pod.spec.containers[].resources``).
+
+See `Managing Compute Resources for Containers <https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/>`_ for more information.

--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -17,6 +17,10 @@ spec:
       size: "5Gi"
       storageClass: "default"
     nodeSelector:
+    resources:
+      requests:
+        cpu: '500m'
+        memory: 2Gi
   image:
     repository: "cassandra"
     tag: "3"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -46,15 +46,20 @@ helm delete --purge "${RELEASE_NAME}" || true
 function debug_navigator_start() {
     kubectl api-versions
     kubectl get pods --all-namespaces
-    kubectl describe deploy
-    kubectl describe pod
+    kubectl describe --namespace "${NAVIGATOR_NAMESPACE}" deploy
+    kubectl describe --namespace "${NAVIGATOR_NAMESPACE}"  pod
 }
 
-function helm_install() {
-    helm delete --purge "${RELEASE_NAME}" || true
+function navigator_install() {
     echo "Installing navigator..."
-    if helm --debug install --wait --name "${RELEASE_NAME}" contrib/charts/navigator \
-         --values ${CHART_VALUES}
+    helm delete --purge "${RELEASE_NAME}" || true
+    kube_delete_namespace_and_wait "${NAVIGATOR_NAMESPACE}"
+    kube_create_namespace_with_quota "${NAVIGATOR_NAMESPACE}"
+    if helm --debug install \
+            --namespace "${NAVIGATOR_NAMESPACE}" \
+            --wait \
+            --name "${RELEASE_NAME}" contrib/charts/navigator \
+            --values ${CHART_VALUES}
     then
         return 0
     fi
@@ -63,7 +68,7 @@ function helm_install() {
 
 # Retry helm install to work around intermittent API server availability.
 # See https://github.com/jetstack/navigator/issues/118
-if ! retry helm_install; then
+if ! retry navigator_install; then
     debug_navigator_start
     echo "ERROR: Failed to install Navigator"
     exit 1
@@ -73,12 +78,14 @@ fi
 function navigator_ready() {
     local replica_count_controller=$(
         kubectl get deployment ${RELEASE_NAME}-navigator-controller \
+                --namespace "${NAVIGATOR_NAMESPACE}" \
                 --output 'jsonpath={.status.readyReplicas}' || true)
     if [[ "${replica_count_controller}" -eq 0 ]]; then
         return 1
     fi
     local replica_count_apiserver=$(
         kubectl get deployment ${RELEASE_NAME}-navigator-apiserver \
+                --namespace "${NAVIGATOR_NAMESPACE}" \
                 --output 'jsonpath={.status.readyReplicas}' || true)
     if [[ "${replica_count_apiserver}" -eq 0 ]]; then
         return 1
@@ -91,7 +98,7 @@ function navigator_ready() {
     if ! kubectl get esc; then
         return 1
     fi
-    if ! kube_event_exists "kube-system" \
+    if ! kube_event_exists "${NAVIGATOR_NAMESPACE}" \
          "navigator-controller:Endpoints:Normal:LeaderElection"
     then
         return 1
@@ -117,7 +124,7 @@ function fail_test() {
 function test_elasticsearchcluster() {
     local namespace="${1}"
     echo "Testing ElasticsearchCluster"
-    kubectl create namespace "${namespace}"
+    kube_create_namespace_with_quota "${namespace}"
     if ! kubectl get esc; then
         fail_test "Failed to use shortname to get ElasticsearchClusters"
     fi
@@ -199,7 +206,7 @@ function test_cassandracluster() {
     export CASS_CQL_PORT=9042
     export CASS_VERSION="3.11.1"
 
-    kubectl create namespace "${namespace}"
+    kube_create_namespace_with_quota "${namespace}"
 
     if ! kubectl get \
          --namespace "${namespace}" \

--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -41,6 +41,14 @@ function retry() {
     done
 }
 
+function kube_create_namespace_with_quota() {
+    local namespace=$1
+    kubectl create namespace "${namespace}"
+    kubectl create quota \
+            --namespace "${namespace}" \
+            --hard=cpu=16,memory=32G navigator-test-quota
+}
+
 function kube_delete_namespace_and_wait() {
     local namespace=$1
     # Delete ESCs and C* clusters in the namespace
@@ -208,6 +216,7 @@ function in_cluster_command() {
         --stdin=true \
         --attach=true \
         --quiet \
+        --limits="cpu=100m,memory=500Mi" \
         -- \
         "${@}"
 }

--- a/hack/testdata/cass-cluster-test.template.yaml
+++ b/hack/testdata/cass-cluster-test.template.yaml
@@ -16,7 +16,11 @@ spec:
       enabled: true
       size: "5Gi"
       storageClass: "default"
-    nodeSelector:
+    nodeSelector: {}
+    resources:
+      requests:
+        cpu: '500m'
+        memory: 2Gi
   pilotImage:
     repository: "${NAVIGATOR_IMAGE_REPOSITORY}/navigator-pilot-cassandra"
     tag: "${NAVIGATOR_IMAGE_TAG}"

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -42,6 +42,7 @@ type CassandraClusterNodePool struct {
 	NodeSelector map[string]string
 	Rack         string
 	Datacenter   string
+	Resources    v1.ResourceRequirements
 }
 
 type CassandraClusterStatus struct {

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -66,6 +66,11 @@ type CassandraClusterNodePool struct {
 	// in this nodepool. If this is not set, a default will be selected.
 	// +optional
 	Datacenter string `json:"datacenter"`
+
+	// Resources specifies the resource requirements to be used for nodes that
+	// are part of the pool.
+	// +optional
+	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type CassandraClusterStatus struct {

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -171,6 +171,7 @@ func autoConvert_v1alpha1_CassandraClusterNodePool_To_navigator_CassandraCluster
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	out.Rack = in.Rack
 	out.Datacenter = in.Datacenter
+	out.Resources = in.Resources
 	return nil
 }
 
@@ -188,6 +189,7 @@ func autoConvert_navigator_CassandraClusterNodePool_To_v1alpha1_CassandraCluster
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	out.Rack = in.Rack
 	out.Datacenter = in.Datacenter
+	out.Resources = in.Resources
 	return nil
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
@@ -99,6 +99,7 @@ func (in *CassandraClusterNodePool) DeepCopyInto(out *CassandraClusterNodePool) 
 			(*out)[key] = val
 		}
 	}
+	in.Resources.DeepCopyInto(&out.Resources)
 	return
 }
 

--- a/pkg/apis/navigator/validation/cassandra.go
+++ b/pkg/apis/navigator/validation/cassandra.go
@@ -11,6 +11,8 @@ import (
 )
 
 func ValidateCassandraClusterNodePool(np *navigator.CassandraClusterNodePool, fldPath *field.Path) field.ErrorList {
+	// TODO: call k8s.io/kubernetes/pkg/apis/core/validation.ValidateResourceRequirements on np.Resources
+	// this will require vendoring kubernetes/kubernetes.
 	return field.ErrorList{}
 }
 

--- a/pkg/apis/navigator/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/zz_generated.deepcopy.go
@@ -99,6 +99,7 @@ func (in *CassandraClusterNodePool) DeepCopyInto(out *CassandraClusterNodePool) 
 			(*out)[key] = val
 		}
 	}
+	in.Resources.DeepCopyInto(&out.Resources)
 	return
 }
 

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -148,6 +148,7 @@ func StatefulSetForCluster(
 								SuccessThreshold:    1,
 								FailureThreshold:    6,
 							},
+							Resources: np.Resources,
 							SecurityContext: &apiv1.SecurityContext{
 								RunAsUser: cluster.Spec.NavigatorClusterConfig.SecurityContext.RunAsUser,
 							},


### PR DESCRIPTION

* Added a ``CassandraClusterNodePoolSpec.Resources`` field, bringing it in line with ``ElasticSearchCluster``.
* Pass the resources through to the nodepool pods.
* Added quotas to all the namespaces in E2E tests, to ensure that tests fail if there Navigator creates pods without resource requests.
* Short description of NodePool resource requests and limits.
* Fixed a problem where a helm-installed Navigator controller would attempt to create leader election events in `kube-system` rather than in the namespace of the helm release.

Fixes: #280


**Release note**:
```release-note
NONE
```
