### PR TITLE
Make nodepool persistence settings immutable

### DIFF
--- a/docs/cassandra.rst
+++ b/docs/cassandra.rst
@@ -15,7 +15,13 @@ Node Pools
 The C* nodes in a Navigator ``cassandracluster`` are configured and grouped by rack and data center
 and in Navigator, these groups of nodes are called ``nodepools``.
 
-All the C* nodes (pods) in a ``nodepool`` have the same configuration and the following sections describe the configuration options that are available:
+All the C* nodes (pods) in a ``nodepool`` have the same configuration and the following sections describe the configuration options that are available.
+
+.. note::
+   Other than the following whitelisted fields, updates to nodepool configuration are not allowed:
+
+   - ``replicas``
+   - ``persistence``
 
 .. include:: configure-scheduler.rst
 

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -19,3 +19,4 @@ nodepool
 scalable
 stateful
 portworx
+whitelisted

--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -9,4 +9,16 @@ Example ``ElasticsearchCluster`` resource:
 .. include:: quick-start/es-cluster-demo.yaml
    :literal:
 
+Node Pools
+----------
+
+The Elasticsearch nodes in a Navigator ``ElasticsearchCluster`` are configured and grouped by role
+and in Navigator, these groups of nodes are called ``nodepools``.
+
+.. note::
+   Other than the following whitelisted fields, updates to nodepool configuration are not allowed:
+
+   - ``replicas``
+   - ``persistence``
+
 .. include:: configure-scheduler.rst

--- a/pkg/apis/navigator/validation/cassandra.go
+++ b/pkg/apis/navigator/validation/cassandra.go
@@ -33,19 +33,23 @@ func ValidateCassandraClusterUpdate(old, new *navigator.CassandraCluster) field.
 
 		for _, oldNp := range old.Spec.NodePools {
 			if newNp.Name == oldNp.Name {
-				if newNp.Rack != oldNp.Rack {
-					allErrs = append(allErrs, field.Forbidden(idxPath.Child("rack"), "cannot modify rack"))
-				}
-				if newNp.Datacenter != oldNp.Datacenter {
-					allErrs = append(allErrs, field.Forbidden(idxPath.Child("datacenter"), "cannot modify datacenter"))
-				}
-				if !reflect.DeepEqual(newNp.NodeSelector, oldNp.NodeSelector) {
-					allErrs = append(allErrs, field.Forbidden(idxPath.Child("nodeSelector"), "cannot modify nodeSelector"))
+				if !reflect.DeepEqual(newNp.Persistence, oldNp.Persistence) {
+					if oldNp.Persistence.Enabled {
+						allErrs = append(allErrs, field.Forbidden(idxPath.Child("persistence"), "cannot modify persistence configuration once enabled"))
+					}
 				}
 
-				if !reflect.DeepEqual(newNp.Persistence, oldNp.Persistence) {
-					allErrs = append(allErrs, field.Forbidden(idxPath.Child("persistence"), "cannot modify persistence configuration"))
+				restoreReplicas := newNp.Replicas
+				newNp.Replicas = oldNp.Replicas
+
+				restorePersistence := newNp.Persistence
+				newNp.Persistence = oldNp.Persistence
+
+				if !reflect.DeepEqual(newNp, oldNp) {
+					allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to nodepool for fields other than 'replicas' and 'persistence' are forbidden."))
 				}
+				newNp.Replicas = restoreReplicas
+				newNp.Persistence = restorePersistence
 
 				break
 			}

--- a/pkg/apis/navigator/validation/cassandra.go
+++ b/pkg/apis/navigator/validation/cassandra.go
@@ -42,6 +42,11 @@ func ValidateCassandraClusterUpdate(old, new *navigator.CassandraCluster) field.
 				if !reflect.DeepEqual(newNp.NodeSelector, oldNp.NodeSelector) {
 					allErrs = append(allErrs, field.Forbidden(idxPath.Child("nodeSelector"), "cannot modify nodeSelector"))
 				}
+
+				if !reflect.DeepEqual(newNp.Persistence, oldNp.Persistence) {
+					allErrs = append(allErrs, field.Forbidden(idxPath.Child("persistence"), "cannot modify persistence configuration"))
+				}
+
 				break
 			}
 		}

--- a/pkg/apis/navigator/validation/cassandra_test.go
+++ b/pkg/apis/navigator/validation/cassandra_test.go
@@ -20,6 +20,13 @@ var (
 			Version: *version.New("5.6.2"),
 			Image:   &validImageSpec,
 			NavigatorClusterConfig: validNavigatorClusterConfig,
+			NodePools: []navigator.CassandraClusterNodePool{
+				navigator.CassandraClusterNodePool{
+					Datacenter:  "datacenter-1",
+					Rack:        "rack-1",
+					Persistence: validNodePoolPersistenceConfig,
+				},
+			},
 		},
 	}
 )
@@ -73,6 +80,84 @@ func TestValidateCassandraCluster(t *testing.T) {
 			title,
 			func(t *testing.T) {
 				errs := validation.ValidateCassandraCluster(tc.cluster)
+				if tc.errorExpected && len(errs) == 0 {
+					t.Errorf("expected error but got none")
+				}
+				if !tc.errorExpected && len(errs) != 0 {
+					t.Errorf("unexpected errors: %s", errs)
+				}
+				for _, e := range errs {
+					t.Logf("error string is: %s", e)
+				}
+			},
+		)
+	}
+}
+
+func TestValidateCassandraClusterUpdate(t *testing.T) {
+	type testT struct {
+		old           *navigator.CassandraCluster
+		new           *navigator.CassandraCluster
+		errorExpected bool
+	}
+
+	setPersistence := func(
+		c *navigator.CassandraCluster,
+		p navigator.PersistenceConfig,
+	) *navigator.CassandraCluster {
+		c = c.DeepCopy()
+		c.Spec.NodePools[0].Persistence = p
+		return c
+	}
+
+	setRack := func(
+		c *navigator.CassandraCluster,
+		rack string,
+	) *navigator.CassandraCluster {
+		c = c.DeepCopy()
+		c.Spec.NodePools[0].Rack = rack
+		return c
+	}
+
+	setDatacenter := func(
+		c *navigator.CassandraCluster,
+		rack string,
+	) *navigator.CassandraCluster {
+		c = c.DeepCopy()
+		c.Spec.NodePools[0].Datacenter = rack
+		return c
+	}
+
+	tests := map[string]testT{
+		"unchanged cluster": {
+			old: validCassCluster,
+			new: validCassCluster,
+		},
+		"changed rack": {
+			old:           validCassCluster,
+			new:           setRack(validCassCluster, "toot"),
+			errorExpected: true,
+		},
+		"changed datacenter": {
+			old:           validCassCluster,
+			new:           setDatacenter(validCassCluster, "doot"),
+			errorExpected: true,
+		},
+	}
+
+	for title, persistence := range persistenceErrorCases {
+		tests[title] = testT{
+			old:           validCassCluster,
+			new:           setPersistence(validCassCluster, persistence),
+			errorExpected: true,
+		}
+	}
+
+	for title, tc := range tests {
+		t.Run(
+			title,
+			func(t *testing.T) {
+				errs := validation.ValidateCassandraClusterUpdate(tc.old, tc.new)
 				if tc.errorExpected && len(errs) == 0 {
 					t.Errorf("expected error but got none")
 				}

--- a/pkg/apis/navigator/validation/cassandra_test.go
+++ b/pkg/apis/navigator/validation/cassandra_test.go
@@ -143,6 +143,10 @@ func TestValidateCassandraClusterUpdate(t *testing.T) {
 			new:           setDatacenter(validCassCluster, "doot"),
 			errorExpected: true,
 		},
+		"enable persistence config": {
+			old: setPersistence(validCassCluster, navigator.PersistenceConfig{Enabled: false}),
+			new: validCassCluster,
+		},
 	}
 
 	for title, persistence := range persistenceErrorCases {

--- a/pkg/apis/navigator/validation/elasticsearch.go
+++ b/pkg/apis/navigator/validation/elasticsearch.go
@@ -114,13 +114,23 @@ func ValidateElasticsearchClusterUpdate(old, new *navigator.ElasticsearchCluster
 
 		for _, oldNp := range old.Spec.NodePools {
 			if newNp.Name == oldNp.Name {
-				if !reflect.DeepEqual(newNp.NodeSelector, oldNp.NodeSelector) {
-					allErrs = append(allErrs, field.Forbidden(idxPath.Child("nodeSelector"), "cannot modify nodeSelector"))
+				if !reflect.DeepEqual(newNp.Persistence, oldNp.Persistence) {
+					if oldNp.Persistence.Enabled {
+						allErrs = append(allErrs, field.Forbidden(idxPath.Child("persistence"), "cannot modify persistence configuration once enabled"))
+					}
 				}
 
-				if !reflect.DeepEqual(newNp.Persistence, oldNp.Persistence) {
-					allErrs = append(allErrs, field.Forbidden(idxPath.Child("persistence"), "cannot modify persistence configuration"))
+				restoreReplicas := newNp.Replicas
+				newNp.Replicas = oldNp.Replicas
+
+				restorePersistence := newNp.Persistence
+				newNp.Persistence = oldNp.Persistence
+
+				if !reflect.DeepEqual(newNp, oldNp) {
+					allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to nodepool for fields other than 'replicas' and 'persistence' are forbidden."))
 				}
+				newNp.Replicas = restoreReplicas
+				newNp.Persistence = restorePersistence
 
 				break
 			}

--- a/pkg/apis/navigator/validation/elasticsearch.go
+++ b/pkg/apis/navigator/validation/elasticsearch.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"reflect"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -99,6 +100,32 @@ func ValidateElasticsearchClusterSpec(spec *navigator.ElasticsearchClusterSpec, 
 func ValidateElasticsearchCluster(esc *navigator.ElasticsearchCluster) field.ErrorList {
 	allErrs := ValidateObjectMeta(&esc.ObjectMeta, true, apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateElasticsearchClusterSpec(&esc.Spec, field.NewPath("spec"))...)
+	return allErrs
+}
+
+func ValidateElasticsearchClusterUpdate(old, new *navigator.ElasticsearchCluster) field.ErrorList {
+	allErrs := ValidateElasticsearchCluster(new)
+
+	fldPath := field.NewPath("spec")
+
+	npPath := fldPath.Child("nodePools")
+	for i, newNp := range new.Spec.NodePools {
+		idxPath := npPath.Index(i)
+
+		for _, oldNp := range old.Spec.NodePools {
+			if newNp.Name == oldNp.Name {
+				if !reflect.DeepEqual(newNp.NodeSelector, oldNp.NodeSelector) {
+					allErrs = append(allErrs, field.Forbidden(idxPath.Child("nodeSelector"), "cannot modify nodeSelector"))
+				}
+
+				if !reflect.DeepEqual(newNp.Persistence, oldNp.Persistence) {
+					allErrs = append(allErrs, field.Forbidden(idxPath.Child("persistence"), "cannot modify persistence configuration"))
+				}
+
+				break
+			}
+		}
+	}
 	return allErrs
 }
 

--- a/pkg/apis/navigator/validation/elasticsearch_test.go
+++ b/pkg/apis/navigator/validation/elasticsearch_test.go
@@ -495,6 +495,10 @@ func TestValidateElasticsearchClusterUpdate(t *testing.T) {
 			old: baseCluster,
 			new: baseCluster,
 		},
+		"enable persistence config": {
+			old: setPersistence(baseCluster, navigator.PersistenceConfig{Enabled: false}),
+			new: baseCluster,
+		},
 	}
 
 	for title, persistence := range persistenceErrorCases {

--- a/pkg/apis/navigator/validation/elasticsearch_test.go
+++ b/pkg/apis/navigator/validation/elasticsearch_test.go
@@ -22,11 +22,7 @@ var (
 		"some": "selector",
 	}
 	// TODO: expand test cases here
-	validNodePoolResources         = corev1.ResourceRequirements{}
-	validNodePoolPersistenceConfig = navigator.PersistenceConfig{
-		Enabled: true,
-		Size:    resource.MustParse("10Gi"),
-	}
+	validNodePoolResources = corev1.ResourceRequirements{}
 
 	validSpecPluginsList = []string{"anything"}
 	validESCluster       = &navigator.ElasticsearchCluster{
@@ -470,5 +466,60 @@ func TestValidateElasticsearchClusterSpec(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateElasticsearchClusterUpdate(t *testing.T) {
+	type testT struct {
+		old           *navigator.ElasticsearchCluster
+		new           *navigator.ElasticsearchCluster
+		errorExpected bool
+	}
+
+	baseCluster := validESCluster.DeepCopy()
+	baseCluster.Spec.NodePools = []navigator.ElasticsearchClusterNodePool{
+		newValidNodePool("test", 3, navigator.ElasticsearchRoleMaster),
+	}
+
+	setPersistence := func(
+		e *navigator.ElasticsearchCluster,
+		p navigator.PersistenceConfig,
+	) *navigator.ElasticsearchCluster {
+		e = e.DeepCopy()
+		e.Spec.NodePools[0].Persistence = p
+		return e
+	}
+
+	tests := map[string]testT{
+		"unchanged cluster": {
+			old: baseCluster,
+			new: baseCluster,
+		},
+	}
+
+	for title, persistence := range persistenceErrorCases {
+		tests[title] = testT{
+			old:           baseCluster,
+			new:           setPersistence(baseCluster, persistence),
+			errorExpected: true,
+		}
+	}
+
+	for title, tc := range tests {
+		t.Run(
+			title,
+			func(t *testing.T) {
+				errs := validation.ValidateElasticsearchClusterUpdate(tc.old, tc.new)
+				if tc.errorExpected && len(errs) == 0 {
+					t.Errorf("expected error but got none")
+				}
+				if !tc.errorExpected && len(errs) != 0 {
+					t.Errorf("unexpected errors: %s", errs)
+				}
+				for _, e := range errs {
+					t.Logf("error string is: %s", e)
+				}
+			},
+		)
 	}
 }

--- a/pkg/apis/navigator/validation/elasticsearch_test.go
+++ b/pkg/apis/navigator/validation/elasticsearch_test.go
@@ -490,6 +490,15 @@ func TestValidateElasticsearchClusterUpdate(t *testing.T) {
 		return e
 	}
 
+	setRole := func(
+		e *navigator.ElasticsearchCluster,
+		r []navigator.ElasticsearchClusterRole,
+	) *navigator.ElasticsearchCluster {
+		e = e.DeepCopy()
+		e.Spec.NodePools[0].Roles = r
+		return e
+	}
+
 	tests := map[string]testT{
 		"unchanged cluster": {
 			old: baseCluster,
@@ -498,6 +507,15 @@ func TestValidateElasticsearchClusterUpdate(t *testing.T) {
 		"enable persistence config": {
 			old: setPersistence(baseCluster, navigator.PersistenceConfig{Enabled: false}),
 			new: baseCluster,
+		},
+		"change role": {
+			old: baseCluster,
+			new: setRole(baseCluster, []navigator.ElasticsearchClusterRole{
+				navigator.ElasticsearchRoleData,
+				navigator.ElasticsearchRoleMaster,
+				navigator.ElasticsearchRoleIngest,
+			}),
+			errorExpected: true,
 		},
 	}
 

--- a/pkg/apis/navigator/validation/generic_test.go
+++ b/pkg/apis/navigator/validation/generic_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/jetstack/navigator/pkg/apis/navigator"
 )
@@ -19,6 +20,10 @@ var (
 		Repository: validImageRepo,
 		PullPolicy: validImagePullPolicy,
 	}
+	validNodePoolPersistenceConfig = navigator.PersistenceConfig{
+		Enabled: true,
+		Size:    resource.MustParse("10Gi"),
+	}
 	validNavigatorClusterConfig = navigator.NavigatorClusterConfig{
 		PilotImage: validImageSpec,
 	}
@@ -30,6 +35,16 @@ var (
 		"missing tag": {
 			Repository: validImageRepo,
 			PullPolicy: validImagePullPolicy,
+		},
+	}
+	persistenceErrorCases = map[string]navigator.PersistenceConfig{
+		"persistence disabled": {
+			Enabled: false,
+			Size:    resource.MustParse("10Gi"),
+		},
+		"persistence increased size": {
+			Enabled: true,
+			Size:    resource.MustParse("25Gi"),
 		},
 	}
 	navigatorClusterConfigErrorCases = map[string]navigator.NavigatorClusterConfig{

--- a/pkg/registry/navigator/escluster/strategy.go
+++ b/pkg/registry/navigator/escluster/strategy.go
@@ -88,8 +88,10 @@ func (esClusterStrategy) Canonicalize(obj runtime.Object) {
 }
 
 func (esClusterStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	esc := obj.(*navigator.ElasticsearchCluster)
-	return validation.ValidateElasticsearchCluster(esc)
+	newEscCluster := obj.(*navigator.ElasticsearchCluster)
+	oldEscCluster := old.(*navigator.ElasticsearchCluster)
+
+	return validation.ValidateElasticsearchClusterUpdate(oldEscCluster, newEscCluster)
 }
 
 // implements interface RESTUpdateStrategy. This implementation validates updates to


### PR DESCRIPTION

**What this PR does / why we need it**: this adds validation to not allow changing persistence settings in cassandra and elasticsearch, and adds test coverage for the update validation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #233

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
