### PR TITLE
Add limits as well requests to all Navigator pod containers.

### DIFF
--- a/contrib/charts/navigator/values.yaml
+++ b/contrib/charts/navigator/values.yaml
@@ -45,7 +45,11 @@ controller:
     tag: latest
     pullPolicy: Always
   logLevel: 2
+
 resources:
   requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
     cpu: 50m
     memory: 64Mi

--- a/docs/cassandra.rst
+++ b/docs/cassandra.rst
@@ -107,18 +107,7 @@ A simplified example:
       nodeSelector:
         failure-domain.beta.kubernetes.io/zone: "europe-west1-d"
 
-Managing Compute Resources for Cassandra Clusters
--------------------------------------------------
-
-Each ``nodepool`` has a ``resources`` attribute which defines the resource requirements and limits for each C* node (pod) in the pool.
-
-In the example above, each C* node (pod) in the ``nodepool`` named ``ringnodes`` will request half a CPU core and 2GiB of memory.
-
-The ``resources`` field follows exactly the same specification as the Kubernetes Pod API
-(``pod.spec.containers[].resources``).
-
-See `Managing Compute Resources for Containers <https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/>`_ for more information.
-
+.. include:: managing-compute-resources.rst
 
 Connecting to Cassandra
 -----------------------

--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -10,3 +10,5 @@ Example ``ElasticsearchCluster`` resource:
    :literal:
 
 .. include:: configure-scheduler.rst
+
+.. include:: managing-compute-resources.rst

--- a/docs/managing-compute-resources.rst
+++ b/docs/managing-compute-resources.rst
@@ -1,0 +1,12 @@
+Managing Compute Resources for Clusters
+---------------------------------------
+
+Each ``nodepool`` has a ``resources`` attribute which defines the resource requirements and limits for each database node (pod) in that pool.
+
+In the example above, each database node will request 0.5 CPU core and 2GiB of memory,
+and will be limited to 1 CPU core and 3GiB of memory.
+
+The ``resources`` field follows exactly the same specification as the Kubernetes Pod API
+(``pod.spec.containers[].resources``).
+
+See `Managing Compute Resources for Containers <https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/>`_ for more information.

--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -18,8 +18,11 @@ spec:
     nodeSelector:
     resources:
       requests:
-        cpu: '500m'
-        memory: 2Gi
+        cpu: "500m"
+        memory: "2Gi"
+      limits:
+        cpu: "1"
+        memory: "3Gi"
   image:
     repository: "cassandra"
     tag: "3"

--- a/docs/quick-start/es-cluster-demo.yaml
+++ b/docs/quick-start/es-cluster-demo.yaml
@@ -28,11 +28,11 @@ spec:
 
     resources:
       requests:
-        cpu: '500m'
-        memory: 2Gi
+        cpu: "500m"
+        memory: "2Gi"
       limits:
-        cpu: '1'
-        memory: 3Gi
+        cpu: "1"
+        memory: "3Gi"
 
     persistence:
       enabled: true
@@ -50,11 +50,11 @@ spec:
 
     resources:
       requests:
-        cpu: '500m'
-        memory: 2Gi
+        cpu: "500m"
+        memory: "2Gi"
       limits:
-        cpu: '1'
-        memory: 3Gi
+        cpu: "1"
+        memory: "3Gi"
 
     persistence:
       enabled: true

--- a/hack/libe2e.sh
+++ b/hack/libe2e.sh
@@ -46,7 +46,8 @@ function kube_create_namespace_with_quota() {
     kubectl create namespace "${namespace}"
     kubectl create quota \
             --namespace "${namespace}" \
-            --hard=cpu=16,memory=32G navigator-test-quota
+            --hard=cpu=16,requests.cpu=16,limits.cpu=16,memory=32G,requests.memory=32G,limits.memory=32G \
+            navigator-test-quota
 }
 
 function kube_delete_namespace_and_wait() {
@@ -220,6 +221,7 @@ function in_cluster_command() {
         --attach=true \
         --quiet \
         --limits="cpu=100m,memory=500Mi" \
+        --requests="cpu=100m,memory=500Mi" \
         -- \
         "${@}"
 }

--- a/hack/testdata/cass-cluster-test.template.yaml
+++ b/hack/testdata/cass-cluster-test.template.yaml
@@ -18,8 +18,11 @@ spec:
     nodeSelector: {}
     resources:
       requests:
-        cpu: '500m'
-        memory: 2Gi
+        cpu: "500m"
+        memory: "2Gi"
+      limits:
+        cpu: "500m"
+        memory: "2Gi"
   pilotImage:
     repository: "${NAVIGATOR_IMAGE_REPOSITORY}/navigator-pilot-cassandra"
     tag: "${NAVIGATOR_IMAGE_TAG}"

--- a/hack/testdata/es-cluster-test.template.yaml
+++ b/hack/testdata/es-cluster-test.template.yaml
@@ -29,8 +29,11 @@ spec:
 
     resources:
       requests:
-        cpu: '500m'
-        memory: 2Gi
+        cpu: "500m"
+        memory: "2Gi"
+      limits:
+        cpu: "500m"
+        memory: "2Gi"
 
     persistence:
       enabled: false

--- a/hack/testdata/values.yaml
+++ b/hack/testdata/values.yaml
@@ -31,8 +31,3 @@ controller:
     repository: jetstackexperimental/navigator-controller
     tag: build
     pullPolicy: Never
-
-resources:
-  requests:
-    cpu: 50m
-    memory: 64Mi

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -335,6 +335,10 @@ func pilotInstallationContainer(
 				apiv1.ResourceCPU:    resource.MustParse("10m"),
 				apiv1.ResourceMemory: resource.MustParse("8Mi"),
 			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("10m"),
+				apiv1.ResourceMemory: resource.MustParse("8Mi"),
+			},
 		},
 	}
 }

--- a/pkg/controllers/elasticsearch/actions/create_nodepool.go
+++ b/pkg/controllers/elasticsearch/actions/create_nodepool.go
@@ -309,6 +309,10 @@ func buildInitContainers(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.Elastics
 				apiv1.ResourceCPU:    resource.MustParse("10m"),
 				apiv1.ResourceMemory: resource.MustParse("8Mi"),
 			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("10m"),
+				apiv1.ResourceMemory: resource.MustParse("8Mi"),
+			},
 		},
 	}
 	for i, sysctl := range c.Spec.Sysctls {
@@ -324,6 +328,10 @@ func buildInitContainers(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.Elastics
 			},
 			Resources: apiv1.ResourceRequirements{
 				Requests: apiv1.ResourceList{
+					apiv1.ResourceCPU:    resource.MustParse("10m"),
+					apiv1.ResourceMemory: resource.MustParse("8Mi"),
+				},
+				Limits: apiv1.ResourceList{
 					apiv1.ResourceCPU:    resource.MustParse("10m"),
 					apiv1.ResourceMemory: resource.MustParse("8Mi"),
 				},


### PR DESCRIPTION
* Builds on #282
* Adds limits to the busybox init container that we use to install the pilot and associated files into the target database container.
* Adds limits to the Navigator API server and controller pods (via the Navigator chart).
* Adds shared documentation for resource requests and limits for Elasticsearch as well as Cassandra.
* Adds limits to all the namespaces that we create in our E2E tests.

Fixes: #280 

**Release note**:
```release-note
NONE
```
