### PR TITLE
Remove the sysctl feature and add documentation instead

### DIFF
--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -20,3 +20,4 @@ scalable
 stateful
 portworx
 whitelisted
+tolerations

--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -24,3 +24,28 @@ and in Navigator, these groups of nodes are called ``nodepools``.
 .. include:: configure-scheduler.rst
 
 .. include:: managing-compute-resources.rst
+
+.. _system-configuration-elastic-search:
+
+System Configuration for Elasticsearch Nodes
+--------------------------------------------
+
+Elasticsearch requires `important system configuration settings <https://www.elastic.co/guide/en/elasticsearch/reference/current/system-config.html>`_ to be applied globally on the host operating system.
+
+You must either ensure that Navigator is running in a Kubernetes cluster where all the nodes have been configured this way.
+Or you could use `node labels and node selectors <https://kubernetes.io/docs/concepts/configuration/assign-pod-node/>`_ to ensure that the pods of an Elasticsearch cluster are only scheduled to nodes with the required configuration.
+
+See `Using Sysctls in a Kubernetes Cluster <https://kubernetes.io/docs/concepts/cluster-administration/sysctl-cluster/>`_,
+and `Taints and Tolerations <https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/>`_ for more information.
+
+One way to apply these settings is to deploy a ``DaemonSet`` that runs the configuration commands from within a privileged container on each Kubernetes node.
+Here's a simple example of such a ``DaemonSet``:
+
+.. code-block:: bash
+
+   $ kubectl apply -f docs/quick-start/sysctl-daemonset.yaml
+
+.. include:: quick-start/sysctl-daemonset.yaml
+   :literal:
+
+:download:`docs/quick-start/sysctl-daemonset.yaml <quick-start/sysctl-daemonset.yaml>`

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -6,6 +6,7 @@ This will involve first deploying Navigator, and then creating an ``Elasticsearc
 All management of the Elasticsearch cluster will be through changes to the ElasticsearchCluster manifest.
 
 1) Install Navigator using `Helm <https://github.com/kubernetes/helm>`_
+-----------------------------------------------------------------------
 
 .. code-block:: bash
 
@@ -19,7 +20,23 @@ You should see the Navigator service start in the ``navigator`` namespace:
     NAME                        READY     STATUS         RESTARTS   AGE
     navigator-745449320-dcgms   1/1       Running        0          30s
 
-2) We can now create a new ElasticsearchCluster:
+2) Prepare your Kubernetes nodes
+--------------------------------
+
+Elasticsearch requires certain `important system configuration settings <https://www.elastic.co/guide/en/elasticsearch/reference/current/system-config.html>`_ to be configured on the host operating system i.e. on the Kubernetes node.
+For this demonstration, it should be sufficient to run ``sysctl -w vm.max_map_count=262144``, which `increases a particular virtual memory limit <https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html>`_.
+You can quickly run the command on *all* your Kubernetes nodes by installing the following ``DaemonSet``:
+
+.. code-block:: bash
+
+  $ kubectl apply -f docs/quick-start/sysctl-daemonset.yaml
+
+Or you can log into each node and run the command by hand.
+
+See :ref:`system-configuration-elastic-search` for more information.
+
+3) Create an Elasticsearch cluster
+----------------------------------
 
 .. code-block:: bash
 
@@ -43,7 +60,8 @@ All of the options you may need for configuring your cluster are documented on t
     es-demo-master-554549909-pp557    1/1       Running   0          7m
     es-demo-master-554549909-vjgrt    1/1       Running   0          7m
 
-3) Scale the data nodes:
+4) Scale the data nodes
+-----------------------
 
 Scaling the nodes can be done by modifying your ElasticsearchCluster manifest.
 Currently this is only possible using ``kubectl replace``, due to bugs with the way ThirdPartyResource's are handled in kubectl 1.5.

--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -4,8 +4,6 @@ metadata:
   name: "demo"
 spec:
   version: "3.11.1"
-  sysctls:
-  - "vm.max_map_count=0"
   nodePools:
   - name: "ringnodes"
     replicas: 3
@@ -15,7 +13,7 @@ spec:
       enabled: true
       size: "5Gi"
       storageClass: "default"
-    nodeSelector:
+    nodeSelector: {}
     resources:
       requests:
         cpu: "500m"

--- a/docs/quick-start/es-cluster-demo.yaml
+++ b/docs/quick-start/es-cluster-demo.yaml
@@ -8,9 +8,6 @@ spec:
   # minimumMasters: 2
   version: 5.6.2
 
-  sysctls:
-  - vm.max_map_count=262144
-
   securityContext:
     runAsUser: 1000
 

--- a/docs/quick-start/sysctl-daemonset.yaml
+++ b/docs/quick-start/sysctl-daemonset.yaml
@@ -1,0 +1,41 @@
+# Apply sysctl configuration required by Elasticsearch
+#
+# This DaemonSet will re-run sysctl every 60s on all nodes.
+#
+# XXX See CronJob daemonset which will allow scheduling one-shot or repeated
+# jobs across nodes:
+# https://github.com/kubernetes/kubernetes/issues/36601
+
+apiVersion: "extensions/v1beta1"
+kind: "DaemonSet"
+metadata:
+  name: "navigator-elasticsearch-sysctl"
+  namespace: "kube-system"
+spec:
+  template:
+    metadata:
+      labels:
+        app: "navigator-elasticsearch-sysctl"
+    spec:
+      containers:
+      - name: "apply-sysctl"
+        image: "busybox:latest"
+        resources:
+          limits:
+            cpu: "10m"
+            memory: "8Mi"
+          requests:
+            cpu: "10m"
+            memory: "8Mi"
+        securityContext:
+          privileged: true
+        command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          set -o errexit
+          set -o xtrace
+          while sysctl -w vm.max_map_count=262144
+          do
+            sleep 60s
+          done

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eux
 
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 source "${SCRIPT_DIR}/libe2e.sh"
@@ -37,3 +38,7 @@ helm init --service-account=tiller
 
 echo "Waiting for tiller to be ready..."
 retry TIMEOUT=60 helm version
+
+echo "Applying Elasticsearch virtual memory configuration on all nodes..."
+# See https://www.elastic.co/guide/en/elasticsearch/reference/current/system-config.html
+kubectl apply --filename "${ROOT_DIR}/docs/quick-start/sysctl-daemonset.yaml"

--- a/hack/testdata/cass-cluster-test.template.yaml
+++ b/hack/testdata/cass-cluster-test.template.yaml
@@ -4,8 +4,6 @@ metadata:
   name: "${CASS_NAME}"
 spec:
   version: "${CASS_VERSION}"
-  sysctls:
-  - "vm.max_map_count=0"
   nodePools:
   - name: "ringnodes"
     replicas: ${CASS_REPLICAS}

--- a/hack/testdata/es-cluster-test.template.yaml
+++ b/hack/testdata/es-cluster-test.template.yaml
@@ -7,9 +7,6 @@ spec:
 
   version: 5.6.2
 
-  sysctls:
-  - vm.max_map_count=262144
-
   securityContext:
     runAsUser: 1000
 

--- a/pkg/apis/navigator/types.go
+++ b/pkg/apis/navigator/types.go
@@ -151,8 +151,6 @@ type NavigatorClusterConfig struct {
 	PilotImage ImageSpec
 
 	SecurityContext NavigatorSecurityContext
-
-	Sysctls []string
 }
 
 type NavigatorSecurityContext struct {

--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -243,10 +243,6 @@ type NavigatorClusterConfig struct {
 
 	// Security related options that are common to all cluster kinds
 	SecurityContext NavigatorSecurityContext `json:"securityContext,omitempty"`
-
-	// Sysctl can be used to specify a list of sysctl values to set on start-up
-	// This can be used to set for example the vm.max_map_count parameter.
-	Sysctls []string `json:"sysctls"`
 }
 
 type NavigatorSecurityContext struct {

--- a/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.conversion.go
@@ -529,7 +529,6 @@ func autoConvert_v1alpha1_NavigatorClusterConfig_To_navigator_NavigatorClusterCo
 	if err := Convert_v1alpha1_NavigatorSecurityContext_To_navigator_NavigatorSecurityContext(&in.SecurityContext, &out.SecurityContext, s); err != nil {
 		return err
 	}
-	out.Sysctls = *(*[]string)(unsafe.Pointer(&in.Sysctls))
 	return nil
 }
 
@@ -545,7 +544,6 @@ func autoConvert_navigator_NavigatorClusterConfig_To_v1alpha1_NavigatorClusterCo
 	if err := Convert_navigator_NavigatorSecurityContext_To_v1alpha1_NavigatorSecurityContext(&in.SecurityContext, &out.SecurityContext, s); err != nil {
 		return err
 	}
-	out.Sysctls = *(*[]string)(unsafe.Pointer(&in.Sysctls))
 	return nil
 }
 

--- a/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/v1alpha1/zz_generated.deepcopy.go
@@ -429,11 +429,6 @@ func (in *NavigatorClusterConfig) DeepCopyInto(out *NavigatorClusterConfig) {
 	*out = *in
 	out.PilotImage = in.PilotImage
 	in.SecurityContext.DeepCopyInto(&out.SecurityContext)
-	if in.Sysctls != nil {
-		in, out := &in.Sysctls, &out.Sysctls
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/apis/navigator/validation/elasticsearch_test.go
+++ b/pkg/apis/navigator/validation/elasticsearch_test.go
@@ -460,8 +460,7 @@ func TestValidateElasticsearchClusterSpec(t *testing.T) {
 					field != "test.plugins" &&
 					field != "test.nodePools" &&
 					field != "test.pilot" &&
-					field != "test.image" &&
-					field != "test.sysctl" {
+					field != "test.image" {
 					t.Errorf("%s: missing prefix for: %v", n, err)
 				}
 			}

--- a/pkg/apis/navigator/validation/generic.go
+++ b/pkg/apis/navigator/validation/generic.go
@@ -1,8 +1,6 @@
 package validation
 
 import (
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -40,13 +38,6 @@ func ValidateImageSpec(img *navigator.ImageSpec, fldPath *field.Path) field.Erro
 func ValidateNavigatorClusterConfig(cfg *navigator.NavigatorClusterConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := ValidateImageSpec(&cfg.PilotImage, fldPath.Child("pilotImage"))
 	allErrs = append(allErrs, ValidateNavigatorSecurityContext(&cfg.SecurityContext, fldPath.Child("securityContext"))...)
-	sysctlsPath := fldPath.Child("sysctls")
-	for i, val := range cfg.Sysctls {
-		parts := strings.Split(val, "=")
-		if len(parts) != 2 {
-			allErrs = append(allErrs, field.Invalid(sysctlsPath.Index(i), val, "should be in format vm.max_map_count=65536"))
-		}
-	}
 	return allErrs
 }
 

--- a/pkg/apis/navigator/zz_generated.deepcopy.go
+++ b/pkg/apis/navigator/zz_generated.deepcopy.go
@@ -429,11 +429,6 @@ func (in *NavigatorClusterConfig) DeepCopyInto(out *NavigatorClusterConfig) {
 	*out = *in
 	out.PilotImage = in.PilotImage
 	in.SecurityContext.DeepCopyInto(&out.SecurityContext)
-	if in.Sysctls != nil {
-		in, out := &in.Sysctls, &out.Sysctls
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/controllers/elasticsearch/actions/create_nodepool.go
+++ b/pkg/controllers/elasticsearch/actions/create_nodepool.go
@@ -291,40 +291,18 @@ func elasticsearchPodTemplateSpec(controllerName string, c *v1alpha1.Elasticsear
 }
 
 func buildInitContainers(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.ElasticsearchClusterNodePool) []apiv1.Container {
-	containers := make([]apiv1.Container, len(c.Spec.Sysctls)+1)
-	containers[0] = apiv1.Container{
-		Name:            "install-pilot",
-		Image:           fmt.Sprintf("%s:%s", c.Spec.PilotImage.Repository, c.Spec.PilotImage.Tag),
-		ImagePullPolicy: apiv1.PullPolicy(c.Spec.PilotImage.PullPolicy),
-		Command:         []string{"cp", "/pilot", fmt.Sprintf("%s/pilot", sharedVolumeMountPath)},
-		VolumeMounts: []apiv1.VolumeMount{
-			{
-				Name:      sharedVolumeName,
-				MountPath: sharedVolumeMountPath,
-				ReadOnly:  false,
-			},
-		},
-		Resources: apiv1.ResourceRequirements{
-			Requests: apiv1.ResourceList{
-				apiv1.ResourceCPU:    resource.MustParse("10m"),
-				apiv1.ResourceMemory: resource.MustParse("8Mi"),
-			},
-			Limits: apiv1.ResourceList{
-				apiv1.ResourceCPU:    resource.MustParse("10m"),
-				apiv1.ResourceMemory: resource.MustParse("8Mi"),
-			},
-		},
-	}
-	for i, sysctl := range c.Spec.Sysctls {
-		containers[i+1] = apiv1.Container{
-			Name:            fmt.Sprintf("tune-sysctl-%d", i),
-			Image:           "busybox:latest",
-			ImagePullPolicy: apiv1.PullIfNotPresent,
-			SecurityContext: &apiv1.SecurityContext{
-				Privileged: util.BoolPtr(true),
-			},
-			Command: []string{
-				"sysctl", "-w", sysctl,
+	return []apiv1.Container{
+		{
+			Name:            "install-pilot",
+			Image:           fmt.Sprintf("%s:%s", c.Spec.PilotImage.Repository, c.Spec.PilotImage.Tag),
+			ImagePullPolicy: apiv1.PullPolicy(c.Spec.PilotImage.PullPolicy),
+			Command:         []string{"cp", "/pilot", fmt.Sprintf("%s/pilot", sharedVolumeMountPath)},
+			VolumeMounts: []apiv1.VolumeMount{
+				{
+					Name:      sharedVolumeName,
+					MountPath: sharedVolumeMountPath,
+					ReadOnly:  false,
+				},
 			},
 			Resources: apiv1.ResourceRequirements{
 				Requests: apiv1.ResourceList{
@@ -336,7 +314,6 @@ func buildInitContainers(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.Elastics
 					apiv1.ResourceMemory: resource.MustParse("8Mi"),
 				},
 			},
-		}
+		},
 	}
-	return containers
 }


### PR DESCRIPTION
* Remove sysctl from example and test manifests.
* Remove sysctl from the API.
* Remove the sysctl init containers
* Remove the sysctl API validation code
* Add documentation about Elasticsearch OS configuration
* Add a daemonset to configure the E2E nodes with the required virtual memory settings (https://github.com/kubernetes/kubernetes/issues/36601 would be a better solution).


Fixes: #286 

**Release note**:
```release-note
NONE
```
