### PR TITLE
WIP: Add NamespaceLifecycle admission controller and enable admission

### DIFF
--- a/cmd/apiserver/plugins.go
+++ b/cmd/apiserver/plugins.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+
+	// Admission controllers
+	"github.com/jetstack/navigator/plugin/pkg/admission/namespace/lifecycle"
+)
+
+// registerAllAdmissionPlugins registers all admission plugins
+func registerAllAdmissionPlugins(plugins *admission.Plugins) {
+	lifecycle.Register(plugins)
+}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator/install"
+)
+
+var (
+	groupFactoryRegistry = make(announced.APIGroupFactoryRegistry)
+	// Registry is an instance of an API registry.
+	Registry = registered.NewOrDie("")
+	// Scheme for API object types
+	Scheme = runtime.NewScheme()
+	// ParameterCodec handles versioning of objects that are converted to query parameters.
+	ParameterCodec = runtime.NewParameterCodec(Scheme)
+	// Codecs for creating a server config
+	Codecs = serializer.NewCodecFactory(Scheme)
+)
+
+func init() {
+	install.Install(groupFactoryRegistry, Registry, Scheme)
+
+	// we need to add the options to empty v1
+	// TODO fix the server code to avoid this
+	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+
+	// TODO: keep the generic API server from wanting this
+	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
+	Scheme.AddUnversionedTypes(unversioned,
+		&metav1.Status{},
+		&metav1.APIVersions{},
+		&metav1.APIGroupList{},
+		&metav1.APIGroup{},
+		&metav1.APIResourceList{},
+	)
+}

--- a/pkg/apiserver/admission/initializer.go
+++ b/pkg/apiserver/admission/initializer.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+
+	"github.com/jetstack/navigator/pkg/client/clientset/internalversion"
+	informers "github.com/jetstack/navigator/pkg/client/informers/internalversion"
+)
+
+// WantsInternalNavigatorClientSet defines a function which sets ClientSet for admission plugins that need it
+type WantsInternalNavigatorClientSet interface {
+	SetInternalNavigatorClientSet(internalversion.Interface)
+	admission.InitializationValidator
+}
+
+// WantsInternalNavigatorInformerFactory defines a function which sets InformerFactory for admission plugins that need it
+type WantsInternalNavigatorInformerFactory interface {
+	SetInternalNavigatorInformerFactory(informers.SharedInformerFactory)
+	admission.InitializationValidator
+}
+
+// WantsKubeClientSet defines a function which sets ClientSet for admission plugins that need it
+type WantsKubeClientSet interface {
+	SetKubeClientSet(kubeclientset.Interface)
+	admission.InitializationValidator
+}
+
+// WantsKubeInformerFactory defines a function which sets InformerFactory for admission plugins that need it
+type WantsKubeInformerFactory interface {
+	SetKubeInformerFactory(kubeinformers.SharedInformerFactory)
+	admission.InitializationValidator
+}
+
+type pluginInitializer struct {
+	internalClient internalversion.Interface
+	informers      informers.SharedInformerFactory
+
+	kubeClient    kubeclientset.Interface
+	kubeInformers kubeinformers.SharedInformerFactory
+}
+
+var _ admission.PluginInitializer = pluginInitializer{}
+
+// NewPluginInitializer constructs new instance of PluginInitializer
+func NewPluginInitializer(internalClient internalversion.Interface, sharedInformers informers.SharedInformerFactory,
+	kubeClient kubeclientset.Interface, kubeInformers kubeinformers.SharedInformerFactory) admission.PluginInitializer {
+	return pluginInitializer{
+		internalClient: internalClient,
+		informers:      sharedInformers,
+		kubeClient:     kubeClient,
+		kubeInformers:  kubeInformers,
+	}
+}
+
+// Initialize checks the initialization interfaces implemented by each plugin
+// and provide the appropriate initialization data
+func (i pluginInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsInternalNavigatorClientSet); ok {
+		wants.SetInternalNavigatorClientSet(i.internalClient)
+	}
+
+	if wants, ok := plugin.(WantsInternalNavigatorInformerFactory); ok {
+		wants.SetInternalNavigatorInformerFactory(i.informers)
+	}
+
+	if wants, ok := plugin.(WantsKubeClientSet); ok {
+		wants.SetKubeClientSet(i.kubeClient)
+	}
+
+	if wants, ok := plugin.(WantsKubeInformerFactory); ok {
+		wants.SetKubeInformerFactory(i.kubeInformers)
+	}
+}

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/golang/glog"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+
+	navadmission "github.com/jetstack/navigator/pkg/apiserver/admission"
+)
+
+const (
+	// PluginName is name of admission plug-in
+	PluginName = "KubernetesNamespaceLifecycle"
+	// how long to wait for a missing namespace before re-checking the cache (and then doing a live lookup)
+	// this accomplishes two things:
+	// 1. It allows a watch-fed cache time to observe a namespace creation event
+	// 2. It allows time for a namespace creation to distribute to members of a storage cluster,
+	//    so the live lookup has a better chance of succeeding even if it isn't performed against the leader.
+	missingNamespaceWait = 50 * time.Millisecond
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(io.Reader) (admission.Interface, error) {
+		return NewLifecycle()
+	})
+}
+
+// lifecycle is an implementation of admission.Interface.
+// It enforces life-cycle constraints around a Namespace depending on its Phase
+type lifecycle struct {
+	*admission.Handler
+	client          kubeclientset.Interface
+	namespaceLister listerscorev1.NamespaceLister
+}
+
+type forceLiveLookupEntry struct {
+	expiry time.Time
+}
+
+var _ = navadmission.WantsKubeInformerFactory(&lifecycle{})
+var _ = navadmission.WantsKubeClientSet(&lifecycle{})
+
+func (l *lifecycle) Admit(a admission.Attributes) error {
+	// we need to wait for our caches to warm
+	if !l.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+
+	var (
+		exists bool
+		err    error
+	)
+
+	namespace, err := l.namespaceLister.Get(a.GetNamespace())
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return errors.NewInternalError(err)
+		}
+	} else {
+		exists = true
+	}
+
+	// we only care about namespaced resources
+	if len(a.GetNamespace()) == 0 {
+		return nil
+	}
+
+	if !exists && a.GetOperation() == admission.Create {
+		// give the cache time to observe the namespace before rejecting a create.
+		// this helps when creating a namespace and immediately creating objects within it.
+		time.Sleep(missingNamespaceWait)
+		namespace, err = l.namespaceLister.Get(a.GetNamespace())
+		switch {
+		case errors.IsNotFound(err):
+			// no-op
+		case err != nil:
+			return errors.NewInternalError(err)
+		default:
+			exists = true
+		}
+		if exists {
+			glog.V(4).Infof("found namespace %q in cache after waiting", a.GetNamespace())
+		}
+	}
+
+	// refuse to operate on non-existent namespaces
+	if !exists {
+		// as a last resort, make a call directly to storage
+		namespace, err = l.client.CoreV1().Namespaces().Get(a.GetNamespace(), metav1.GetOptions{})
+		switch {
+		case errors.IsNotFound(err):
+			return err
+		case err != nil:
+			return errors.NewInternalError(err)
+		}
+		glog.V(4).Infof("found namespace %q via storage lookup", a.GetNamespace())
+	}
+
+	// ensure that we're not trying to create objects in terminating namespaces
+	if a.GetOperation() == admission.Create {
+		if namespace.Status.Phase != corev1.NamespaceTerminating {
+			return nil
+		}
+
+		return admission.NewForbidden(a, fmt.Errorf("unable to create new content in namespace %q because it is being terminated", a.GetNamespace()))
+	}
+
+	return nil
+}
+
+// NewLifecycle creates a new namespace lifecycle admission control handler
+func NewLifecycle() (admission.Interface, error) {
+	return &lifecycle{
+		Handler: admission.NewHandler(admission.Create, admission.Update, admission.Delete),
+	}, nil
+}
+
+func (l *lifecycle) SetKubeInformerFactory(f kubeinformers.SharedInformerFactory) {
+	namespaceInformer := f.Core().V1().Namespaces()
+	l.namespaceLister = namespaceInformer.Lister()
+	l.SetReadyFunc(namespaceInformer.Informer().HasSynced)
+}
+
+func (l *lifecycle) SetKubeClientSet(client kubeclientset.Interface) {
+	l.client = client
+}
+
+func (l *lifecycle) ValidateInitialization() error {
+	if l.namespaceLister == nil {
+		return fmt.Errorf("missing namespaceLister")
+	}
+	if l.client == nil {
+		return fmt.Errorf("missing client")
+	}
+	return nil
+}

--- a/plugin/pkg/admission/namespace/lifecycle/admission_test.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/admission"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+
+	kubeinformers "k8s.io/client-go/informers"
+	kubeclientset "k8s.io/client-go/kubernetes"
+
+	"github.com/jetstack/navigator/pkg/apis/navigator"
+	"github.com/jetstack/navigator/pkg/client/clientset_generated/internalclientset"
+	"github.com/jetstack/navigator/pkg/client/clientset_generated/internalclientset/fake"
+	informers "github.com/jetstack/navigator/pkg/client/informers_generated/internalversion"
+
+	navadmission "github.com/jetstack/navigator/pkg/apiserver/admission"
+)
+
+// newHandlerForTest returns a configured handler for testing.
+func newHandlerForTest(internalClient internalclientset.Interface, kubeClient kubeclientset.Interface) (admission.Interface, informers.SharedInformerFactory, kubeinformers.SharedInformerFactory, error) {
+	f := informers.NewSharedInformerFactory(internalClient, 5*time.Minute)
+	kf := kubeinformers.NewSharedInformerFactory(kubeClient, 5*time.Minute)
+	handler, err := NewLifecycle()
+	if err != nil {
+		return nil, f, kf, err
+	}
+	pluginInitializer := navadmission.NewPluginInitializer(internalClient, f, kubeClient, kf)
+	pluginInitializer.Initialize(handler)
+	err = admission.ValidateInitialization(handler)
+	return handler, f, kf, err
+}
+
+// newMockKubeClientForTest creates a mock client that returns a client
+// configured for the specified list of namespaces with the specified phase.
+func newMockKubeClientForTest(namespaces map[string]corev1.NamespacePhase) *kubefake.Clientset {
+	mockClient := &kubefake.Clientset{}
+	mockClient.AddReactor("list", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
+		namespaceList := &corev1.NamespaceList{
+			ListMeta: metav1.ListMeta{
+				ResourceVersion: fmt.Sprintf("%d", len(namespaces)),
+			},
+		}
+		index := 0
+		for name, phase := range namespaces {
+			namespaceList.Items = append(namespaceList.Items, corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            name,
+					ResourceVersion: fmt.Sprintf("%d", index),
+				},
+				Status: corev1.NamespaceStatus{
+					Phase: phase,
+				},
+			})
+			index++
+		}
+		return true, namespaceList, nil
+	})
+	return mockClient
+}
+
+// newMockClientForTest creates a mock client.
+func newMockClientForTest() *fake.Clientset {
+	mockClient := &fake.Clientset{}
+	return mockClient
+}
+
+// newElasticsearchCluster returns a new instance for the specified namespace.
+func newElasticsearchCluster(namespace string) navigator.ElasticsearchCluster {
+	return navigator.ElasticsearchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "instance", Namespace: namespace},
+	}
+}
+
+// TestAdmissionNamespaceDoesNotExist verifies instance is not admitted if namespace does not exist.
+func TestAdmissionNamespaceDoesNotExist(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest()
+	mockKubeClient := newMockKubeClientForTest(map[string]corev1.NamespacePhase{})
+	mockKubeClient.AddReactor("get", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("nope, out of luck")
+	})
+	handler, informerFactory, kubeInformerFactory, err := newHandlerForTest(mockClient, mockKubeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+	kubeInformerFactory.Start(wait.NeverStop)
+
+	instance := newElasticsearchCluster(namespace)
+	err = handler.(admission.MutationInterface).Admit(admission.NewAttributesRecord(&instance, nil, navigator.Kind("ElasticsearchCluster").WithVersion("version"), instance.Namespace, instance.Name, navigator.Resource("ElasticsearchClusters").WithVersion("version"), "", admission.Create, nil))
+	if err == nil {
+		actions := ""
+		for _, action := range mockClient.Actions() {
+			actions = actions + action.GetVerb() + ":" + action.GetResource().Resource + ":" + action.GetSubresource() + ", "
+		}
+		t.Errorf("expected error returned from admission handler: %v", actions)
+	}
+}
+
+// TestAdmissionNamespaceActive verifies a resource is admitted when the namespace is active.
+func TestAdmissionNamespaceActive(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest()
+	mockKubeClient := newMockKubeClientForTest(map[string]corev1.NamespacePhase{
+		namespace: corev1.NamespaceActive,
+	})
+	handler, informerFactory, kubeInformerFactory, err := newHandlerForTest(mockClient, mockKubeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+	kubeInformerFactory.Start(wait.NeverStop)
+
+	instance := newElasticsearchCluster(namespace)
+	err = handler.(admission.MutationInterface).Admit(admission.NewAttributesRecord(&instance, nil, navigator.Kind("ElasticsearchCluster").WithVersion("version"), instance.Namespace, instance.Name, navigator.Resource("ElasticsearchClusters").WithVersion("version"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("unexpected error returned from admission handler")
+	}
+}
+
+// TestAdmissionNamespaceTerminating verifies a resource is not created when the namespace is terminating.
+func TestAdmissionNamespaceTerminating(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest()
+	mockKubeClient := newMockKubeClientForTest(map[string]corev1.NamespacePhase{
+		namespace: corev1.NamespaceTerminating,
+	})
+	handler, informerFactory, kubeInformerFactory, err := newHandlerForTest(mockClient, mockKubeClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+	kubeInformerFactory.Start(wait.NeverStop)
+
+	instance := newElasticsearchCluster(namespace)
+	err = handler.(admission.MutationInterface).Admit(admission.NewAttributesRecord(&instance, nil, navigator.Kind("ElasticsearchCluster").WithVersion("version"), instance.Namespace, instance.Name, navigator.Resource("ElasticsearchClusters").WithVersion("version"), "", admission.Create, nil))
+	if err == nil {
+		t.Errorf("Expected error rejecting creates in a namespace when it is terminating")
+	}
+
+	// verify update operations in the namespace can proceed
+	err = handler.(admission.MutationInterface).Admit(admission.NewAttributesRecord(&instance, nil, navigator.Kind("ElasticsearchCluster").WithVersion("version"), instance.Namespace, instance.Name, navigator.Resource("ElasticsearchClusters").WithVersion("version"), "", admission.Update, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+
+	// verify delete operations in the namespace can proceed
+	err = handler.(admission.MutationInterface).Admit(admission.NewAttributesRecord(nil, nil, navigator.Kind("ElasticsearchCluster").WithVersion("version"), instance.Namespace, instance.Name, navigator.Resource("ElasticsearchClusters").WithVersion("version"), "", admission.Delete, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the NamespaceLifecycle admission controller, and enables admission control in the apiserver using a PluginInitializer that supports injecting both a kube & navigator clientset/informer factory.

**Which issue this PR fixes**: fixes #231 

**Special notes for your reviewer**:

This needs an e2e test to ensure admission control is working properly by default

**Release note**:
```release-note
Fix bug where Navigator resources could be created in namespaces that did not exist
```
