### PR TITLE
Use new test fixture in Cassandra controls

### DIFF
--- a/docs/cassandra.rst
+++ b/docs/cassandra.rst
@@ -174,3 +174,5 @@ For example, you could use the `Datastax Python driver <http://datastax.github.i
 .. note::
    The IP address to which the driver makes the initial connection
    depends on the DNS server and operating system configuration.
+
+.. include:: supplementary-resources.rst

--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -25,6 +25,8 @@ and in Navigator, these groups of nodes are called ``nodepools``.
 
 .. include:: managing-compute-resources.rst
 
+.. include:: supplementary-resources.rst
+
 .. _system-configuration-elastic-search:
 
 System Configuration for Elasticsearch Nodes

--- a/docs/supplementary-resources.rst
+++ b/docs/supplementary-resources.rst
@@ -1,0 +1,7 @@
+Other Supplementary Resources
+-----------------------------
+
+Navigator will also create a number of supplementary resources for each cluster.
+For example it will create a ``serviceaccount``, a ``role`` and a ``rolebinding``
+so that pilot pods in a cluster have read-only access the API resources containing cluster configuration,
+and so that pilot pods can update the status of their corresponding ``Pilot`` resource and leader election ``configmap``.

--- a/internal/test/unit/framework/state_fixture.go
+++ b/internal/test/unit/framework/state_fixture.go
@@ -53,14 +53,17 @@ func (s *StateFixture) Start() {
 	s.kubeSharedInformerFactory = kubeinformers.NewSharedInformerFactory(s.kubeClient, informerResyncPeriod)
 	s.navigatorSharedInformerFactory = informers.NewSharedInformerFactory(s.navigatorClient, informerResyncPeriod)
 	s.state = &controllers.State{
-		Clientset:          s.kubeClient,
-		NavigatorClientset: s.navigatorClient,
-		Recorder:           record.NewFakeRecorder(5),
-		StatefulSetLister:  s.kubeSharedInformerFactory.Apps().V1beta1().StatefulSets().Lister(),
-		ConfigMapLister:    s.kubeSharedInformerFactory.Core().V1().ConfigMaps().Lister(),
-		PilotLister:        s.navigatorSharedInformerFactory.Navigator().V1alpha1().Pilots().Lister(),
-		PodLister:          s.kubeSharedInformerFactory.Core().V1().Pods().Lister(),
-		ServiceLister:      s.kubeSharedInformerFactory.Core().V1().Services().Lister(),
+		Clientset:            s.kubeClient,
+		NavigatorClientset:   s.navigatorClient,
+		Recorder:             record.NewFakeRecorder(5),
+		StatefulSetLister:    s.kubeSharedInformerFactory.Apps().V1beta1().StatefulSets().Lister(),
+		ConfigMapLister:      s.kubeSharedInformerFactory.Core().V1().ConfigMaps().Lister(),
+		PilotLister:          s.navigatorSharedInformerFactory.Navigator().V1alpha1().Pilots().Lister(),
+		PodLister:            s.kubeSharedInformerFactory.Core().V1().Pods().Lister(),
+		ServiceLister:        s.kubeSharedInformerFactory.Core().V1().Services().Lister(),
+		ServiceAccountLister: s.kubeSharedInformerFactory.Core().V1().ServiceAccounts().Lister(),
+		RoleBindingLister:    s.kubeSharedInformerFactory.Rbac().V1beta1().RoleBindings().Lister(),
+		RoleLister:           s.kubeSharedInformerFactory.Rbac().V1beta1().Roles().Lister(),
 	}
 	s.stopCh = make(chan struct{})
 	s.kubeSharedInformerFactory.Start(s.stopCh)

--- a/pkg/controllers/cassandra/role/control_test.go
+++ b/pkg/controllers/cassandra/role/control_test.go
@@ -1,40 +1,85 @@
 package role_test
 
 import (
-	"fmt"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jetstack/navigator/internal/test/unit/framework"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/role"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 )
 
 func TestRoleSync(t *testing.T) {
-	t.Run(
-		"role missing",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.Run()
-			f.AssertRolesLength(1)
+	cluster1 := casstesting.ClusterForTest()
+	role1 := role.RoleForCluster(cluster1)
+	foreignRole1 := role1.DeepCopy()
+	foreignRole1.SetOwnerReferences([]v1.OwnerReference{})
+
+	type testT struct {
+		kubeObjects []runtime.Object
+		cluster     *v1alpha1.CassandraCluster
+		assertions  func(*testing.T, *controllers.State, testT)
+		expectErr   bool
+	}
+	tests := map[string]testT{
+		"create if not listed": {
+			cluster: cluster1,
+			assertions: func(t *testing.T, state *controllers.State, test testT) {
+				expectedObject := role1
+				_, err := state.Clientset.
+					RbacV1beta1().
+					Roles(expectedObject.Namespace).
+					Get(expectedObject.Name, v1.GetOptions{})
+				if err != nil {
+					t.Error(err)
+				}
+			},
 		},
-	)
-	t.Run(
-		"role exists",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			existingRole := role.RoleForCluster(f.Cluster)
-			f.AddObjectK(existingRole)
-			f.Run()
-			f.AssertRolesLength(1)
+		"no error if already listed": {
+			kubeObjects: []runtime.Object{role1},
+			cluster:     cluster1,
 		},
-	)
-	t.Run(
-		"sync fails",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.RoleControl = &casstesting.FakeControl{
-				SyncError: fmt.Errorf("simulated sync error"),
-			}
-			f.RunExpectError()
+		"error if foreign owned": {
+			kubeObjects: []runtime.Object{foreignRole1},
+			cluster:     cluster1,
+			expectErr:   true,
 		},
-	)
+	}
+
+	for title, test := range tests {
+		t.Run(
+			title,
+			func(t *testing.T) {
+				fixture := &framework.StateFixture{
+					T:           t,
+					KubeObjects: test.kubeObjects,
+				}
+				fixture.Start()
+				defer fixture.Stop()
+				state := fixture.State()
+				c := role.NewControl(
+					state.Clientset,
+					state.RoleLister,
+					state.Recorder,
+				)
+				err := c.Sync(test.cluster)
+				if err == nil {
+					if test.expectErr {
+						t.Error("Expected an error")
+					}
+				} else {
+					if !test.expectErr {
+						t.Error(err)
+					}
+				}
+				if test.assertions != nil {
+					test.assertions(t, state, test)
+				}
+			},
+		)
+	}
 }

--- a/pkg/controllers/cassandra/rolebinding/control_test.go
+++ b/pkg/controllers/cassandra/rolebinding/control_test.go
@@ -1,40 +1,85 @@
 package rolebinding_test
 
 import (
-	"fmt"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jetstack/navigator/internal/test/unit/framework"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/rolebinding"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 )
 
 func TestRoleBindingSync(t *testing.T) {
-	t.Run(
-		"role missing",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.Run()
-			f.AssertRoleBindingsLength(1)
+	cluster1 := casstesting.ClusterForTest()
+	rb1 := rolebinding.RoleBindingForCluster(cluster1)
+	foreignRB1 := rb1.DeepCopy()
+	foreignRB1.SetOwnerReferences([]v1.OwnerReference{})
+
+	type testT struct {
+		kubeObjects []runtime.Object
+		cluster     *v1alpha1.CassandraCluster
+		assertions  func(*testing.T, *controllers.State, testT)
+		expectErr   bool
+	}
+	tests := map[string]testT{
+		"create if not listed": {
+			cluster: cluster1,
+			assertions: func(t *testing.T, state *controllers.State, test testT) {
+				expectedObject := rb1
+				_, err := state.Clientset.
+					RbacV1beta1().
+					RoleBindings(expectedObject.Namespace).
+					Get(expectedObject.Name, v1.GetOptions{})
+				if err != nil {
+					t.Error(err)
+				}
+			},
 		},
-	)
-	t.Run(
-		"role exists",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			existingRoleBinding := rolebinding.RoleBindingForCluster(f.Cluster)
-			f.AddObjectK(existingRoleBinding)
-			f.Run()
-			f.AssertRoleBindingsLength(1)
+		"no error if already listed": {
+			kubeObjects: []runtime.Object{rb1},
+			cluster:     cluster1,
 		},
-	)
-	t.Run(
-		"sync fails",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.RoleBindingControl = &casstesting.FakeControl{
-				SyncError: fmt.Errorf("simulated sync error"),
-			}
-			f.RunExpectError()
+		"error if foreign owned": {
+			kubeObjects: []runtime.Object{foreignRB1},
+			cluster:     cluster1,
+			expectErr:   true,
 		},
-	)
+	}
+
+	for title, test := range tests {
+		t.Run(
+			title,
+			func(t *testing.T) {
+				fixture := &framework.StateFixture{
+					T:           t,
+					KubeObjects: test.kubeObjects,
+				}
+				fixture.Start()
+				defer fixture.Stop()
+				state := fixture.State()
+				c := rolebinding.NewControl(
+					state.Clientset,
+					state.RoleBindingLister,
+					state.Recorder,
+				)
+				err := c.Sync(test.cluster)
+				if err == nil {
+					if test.expectErr {
+						t.Error("Expected an error")
+					}
+				} else {
+					if !test.expectErr {
+						t.Error(err)
+					}
+				}
+				if test.assertions != nil {
+					test.assertions(t, state, test)
+				}
+			},
+		)
+	}
 }

--- a/pkg/controllers/cassandra/serviceaccount/control_test.go
+++ b/pkg/controllers/cassandra/serviceaccount/control_test.go
@@ -1,40 +1,85 @@
 package serviceaccount_test
 
 import (
-	"fmt"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jetstack/navigator/internal/test/unit/framework"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/serviceaccount"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 )
 
 func TestServiceAccountSync(t *testing.T) {
-	t.Run(
-		"service account missing",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.Run()
-			f.AssertServiceAccountsLength(1)
+	cluster1 := casstesting.ClusterForTest()
+	sa1 := serviceaccount.ServiceAccountForCluster(cluster1)
+	foreignSA1 := sa1.DeepCopy()
+	foreignSA1.SetOwnerReferences([]v1.OwnerReference{})
+
+	type testT struct {
+		kubeObjects []runtime.Object
+		cluster     *v1alpha1.CassandraCluster
+		assertions  func(*testing.T, *controllers.State, testT)
+		expectErr   bool
+	}
+	tests := map[string]testT{
+		"create service account": {
+			cluster: cluster1,
+			assertions: func(t *testing.T, state *controllers.State, test testT) {
+				expectedObject := sa1
+				_, err := state.Clientset.
+					CoreV1().
+					ServiceAccounts(expectedObject.Namespace).
+					Get(expectedObject.Name, v1.GetOptions{})
+				if err != nil {
+					t.Error(err)
+				}
+			},
 		},
-	)
-	t.Run(
-		"service account exists",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			existingServiceaccount := serviceaccount.ServiceAccountForCluster(f.Cluster)
-			f.AddObjectK(existingServiceaccount)
-			f.Run()
-			f.AssertServiceAccountsLength(1)
+		"service exists": {
+			kubeObjects: []runtime.Object{sa1},
+			cluster:     cluster1,
 		},
-	)
-	t.Run(
-		"sync fails",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.ServiceAccountControl = &casstesting.FakeControl{
-				SyncError: fmt.Errorf("simulated sync error"),
-			}
-			f.RunExpectError()
+		"error if foreign owned": {
+			kubeObjects: []runtime.Object{foreignSA1},
+			cluster:     cluster1,
+			expectErr:   true,
 		},
-	)
+	}
+
+	for title, test := range tests {
+		t.Run(
+			title,
+			func(t *testing.T) {
+				fixture := &framework.StateFixture{
+					T:           t,
+					KubeObjects: test.kubeObjects,
+				}
+				fixture.Start()
+				defer fixture.Stop()
+				state := fixture.State()
+				c := serviceaccount.NewControl(
+					state.Clientset,
+					state.ServiceAccountLister,
+					state.Recorder,
+				)
+				err := c.Sync(test.cluster)
+				if err == nil {
+					if test.expectErr {
+						t.Error("Expected an error")
+					}
+				} else {
+					if !test.expectErr {
+						t.Error(err)
+					}
+				}
+				if test.assertions != nil {
+					test.assertions(t, state, test)
+				}
+			},
+		)
+	}
 }

--- a/pkg/controllers/executor.go
+++ b/pkg/controllers/executor.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	rbaclisters "k8s.io/client-go/listers/rbac/v1beta1"
 	"k8s.io/client-go/tools/record"
 
 	clientset "github.com/jetstack/navigator/pkg/client/clientset/versioned"
@@ -19,11 +20,14 @@ type State struct {
 	NavigatorClientset clientset.Interface
 	Recorder           record.EventRecorder
 
-	StatefulSetLister appslisters.StatefulSetLister
-	ConfigMapLister   corelisters.ConfigMapLister
-	PilotLister       listers.PilotLister
-	PodLister         corelisters.PodLister
-	ServiceLister     corelisters.ServiceLister
+	StatefulSetLister    appslisters.StatefulSetLister
+	ConfigMapLister      corelisters.ConfigMapLister
+	PilotLister          listers.PilotLister
+	PodLister            corelisters.PodLister
+	ServiceLister        corelisters.ServiceLister
+	ServiceAccountLister corelisters.ServiceAccountLister
+	RoleBindingLister    rbaclisters.RoleBindingLister
+	RoleLister           rbaclisters.RoleLister
 }
 
 type Action interface {


### PR DESCRIPTION
I'm trying to get rid of the Cassandra specific test fixture in `./pkg/controllers/cassandra/testing`
In this branch I've switched:
* ServiceAccounts
* Roles
* RoleBindings

I'll deal with Pilot and NodePool controls in separate branches.

**Release note**:

```release-note
NONE
```
