### PR TITLE
Use new unit test fixture for pilot control tests

### DIFF
--- a/docs/supplementary-resources.rst
+++ b/docs/supplementary-resources.rst
@@ -1,3 +1,11 @@
+Pilots
+------
+
+Navigator creates one ``Pilot`` resource for every database node.
+``Pilot`` resources have the same name and name space as the ``Pod`` for the corresponding database node.
+The ``Pilot.Spec`` is read by the pilot process running inside a ``Pod`` and contains its desired configuration.
+The ``Pilot.Status``  is updated by the pilot process and contains the discovered state of a single database node.
+
 Other Supplementary Resources
 -----------------------------
 


### PR DESCRIPTION
* Removes the Pilot Update code. Instead we (for now) only create missing pilots.
* Later the pilot creation and deletion will be done by the ScaleOut and ScaleIn actions.
* Also makes the pilot control gracefully handle the situation where the pilot list doesn't yet have latest pilots and pilot creation therefore results in an AlreadyExists error.

**Release note**:
```release-note
NONE
```
