### PR TITLE
Use new unit test fixture for nodepool control tests

### DIFF
--- a/pkg/controllers/cassandra/nodepool/nodepool_test.go
+++ b/pkg/controllers/cassandra/nodepool/nodepool_test.go
@@ -3,31 +3,93 @@ package nodepool_test
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jetstack/navigator/internal/test/unit/framework"
+	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/nodepool"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 )
 
 func TestNodePoolControlSync(t *testing.T) {
-	t.Run(
-		"create a statefulset",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.Run()
-			f.AssertStatefulSetsLength(1)
+	cluster1 := casstesting.ClusterForTest()
+	set1 := nodepool.StatefulSetForCluster(cluster1, &cluster1.Spec.NodePools[0])
+
+	type testT struct {
+		kubeObjects        []runtime.Object
+		navObjects         []runtime.Object
+		cluster            *v1alpha1.CassandraCluster
+		fixtureManipulator func(*testing.T, *framework.StateFixture)
+		assertions         func(*testing.T, *controllers.State, testT)
+		expectErr          bool
+	}
+
+	tests := map[string]testT{
+		"create if not exists": {
+			cluster: cluster1,
+			assertions: func(t *testing.T, state *controllers.State, test testT) {
+				expectedObject := set1
+				_, err := state.Clientset.AppsV1beta1().
+					StatefulSets(expectedObject.Namespace).
+					Get(expectedObject.Name, v1.GetOptions{})
+				if err != nil {
+					t.Error(err)
+				}
+			},
 		},
-	)
-	t.Run(
-		"ignore existing statefulset",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.AddObjectK(
-				nodepool.StatefulSetForCluster(
-					f.Cluster,
-					&f.Cluster.Spec.NodePools[0],
-				),
-			)
-			f.Run()
-			f.AssertStatefulSetsLength(1)
+
+		"service exists": {
+			kubeObjects: []runtime.Object{set1},
+			cluster:     cluster1,
 		},
-	)
+		"not yet listed": {
+			kubeObjects: []runtime.Object{},
+			cluster:     cluster1,
+			fixtureManipulator: func(t *testing.T, fixture *framework.StateFixture) {
+				_, err := fixture.KubeClient().AppsV1beta1().StatefulSets(set1.Namespace).Create(set1)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for title, test := range tests {
+		t.Run(
+			title,
+			func(t *testing.T) {
+				fixture := &framework.StateFixture{
+					T:                t,
+					KubeObjects:      test.kubeObjects,
+					NavigatorObjects: test.navObjects,
+				}
+				fixture.Start()
+				defer fixture.Stop()
+				if test.fixtureManipulator != nil {
+					test.fixtureManipulator(t, fixture)
+				}
+				state := fixture.State()
+				c := nodepool.NewControl(
+					state.Clientset,
+					state.StatefulSetLister,
+					state.Recorder,
+				)
+				err := c.Sync(test.cluster)
+				if err == nil {
+					if test.expectErr {
+						t.Error("Expected an error")
+					}
+				} else {
+					if !test.expectErr {
+						t.Error(err)
+					}
+				}
+				if test.assertions != nil {
+					test.assertions(t, state, test)
+				}
+			},
+		)
+	}
 }

--- a/pkg/controllers/cassandra/nodepool/nodepool_test.go
+++ b/pkg/controllers/cassandra/nodepool/nodepool_test.go
@@ -30,39 +30,4 @@ func TestNodePoolControlSync(t *testing.T) {
 			f.AssertStatefulSetsLength(1)
 		},
 	)
-	t.Run(
-		"update statefulset",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			unsyncedSet := nodepool.StatefulSetForCluster(
-				f.Cluster,
-				&f.Cluster.Spec.NodePools[0],
-			)
-			unsyncedSet.SetLabels(map[string]string{})
-			f.AddObjectK(unsyncedSet)
-			f.Run()
-			f.AssertStatefulSetsLength(1)
-			sets := f.StatefulSets()
-			set := sets.Items[0]
-			labels := set.GetLabels()
-			if len(labels) == 0 {
-				t.Log(set)
-				t.Error("StatefulSet was not updated")
-			}
-		},
-	)
-	t.Run(
-		"error on update foreign statefulset",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			foreignUnsyncedSet := nodepool.StatefulSetForCluster(
-				f.Cluster,
-				&f.Cluster.Spec.NodePools[0],
-			)
-			foreignUnsyncedSet.SetLabels(map[string]string{})
-			foreignUnsyncedSet.OwnerReferences = nil
-			f.AddObjectK(foreignUnsyncedSet)
-			f.RunExpectError()
-		},
-	)
 }

--- a/pkg/controllers/cassandra/nodepool/nodepool_test.go
+++ b/pkg/controllers/cassandra/nodepool/nodepool_test.go
@@ -3,7 +3,6 @@ package nodepool_test
 import (
 	"testing"
 
-	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/nodepool"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 )
@@ -63,36 +62,6 @@ func TestNodePoolControlSync(t *testing.T) {
 			foreignUnsyncedSet.SetLabels(map[string]string{})
 			foreignUnsyncedSet.OwnerReferences = nil
 			f.AddObjectK(foreignUnsyncedSet)
-			f.RunExpectError()
-		},
-	)
-	t.Run(
-		"delete statefulset without nodepool",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			f.AddObjectK(
-				nodepool.StatefulSetForCluster(
-					f.Cluster,
-					&f.Cluster.Spec.NodePools[0],
-				),
-			)
-			f.Cluster.Spec.NodePools = []v1alpha1.CassandraClusterNodePool{}
-			f.Run()
-			f.AssertStatefulSetsLength(0)
-		},
-	)
-	t.Run(
-		"do not delete foreign owned stateful sets",
-		func(t *testing.T) {
-			f := casstesting.NewFixture(t)
-			foreignStatefulSet := nodepool.StatefulSetForCluster(
-				f.Cluster,
-				&f.Cluster.Spec.NodePools[0],
-			)
-			foreignStatefulSet.OwnerReferences = nil
-
-			f.AddObjectK(foreignStatefulSet)
-			f.Cluster.Spec.NodePools = []v1alpha1.CassandraClusterNodePool{}
 			f.RunExpectError()
 		},
 	)


### PR DESCRIPTION
* Removes most of the StatefulSet Update code. Instead we (for now) only create missing pilots and update when the replica count needs to be increased.
* Later the statefulset creation will be done by the CreateNodePool  actions.
* Also makes the nodepool control gracefully handle the situation where the statefulset lister doesn't yet have latest statefulsets.

**Release note**:
```release-note
NONE
```
