### PR TITLE
Remove duplicate Int32Ptr and Int64Ptr functions

### DIFF
--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+	"github.com/jetstack/navigator/pkg/util/ptr"
 )
 
 const (
@@ -48,7 +49,7 @@ func StatefulSetForCluster(
 			OwnerReferences: []metav1.OwnerReference{util.NewControllerRef(cluster)},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas: util.Int32Ptr(int32(np.Replicas)),
+			Replicas: ptr.Int32(np.Replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: nodePoolLabels,
 			},

--- a/pkg/controllers/cassandra/util/util.go
+++ b/pkg/controllers/cassandra/util/util.go
@@ -77,10 +77,6 @@ func NodePoolLabels(
 	return labels
 }
 
-func Int32Ptr(i int32) *int32 {
-	return &i
-}
-
 func OwnerCheck(
 	obj metav1.Object,
 	owner metav1.Object,

--- a/pkg/controllers/elasticsearch/actions/create_nodepool.go
+++ b/pkg/controllers/elasticsearch/actions/create_nodepool.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers"
 	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
+	"github.com/jetstack/navigator/pkg/util/ptr"
 )
 
 const (
@@ -70,7 +71,7 @@ func nodePoolStatefulSet(c *v1alpha1.ElasticsearchCluster, np *v1alpha1.Elastics
 			},
 		},
 		Spec: apps.StatefulSetSpec{
-			Replicas:    util.Int32Ptr(int32(np.Replicas)),
+			Replicas:    ptr.Int32(np.Replicas),
 			ServiceName: statefulSetName,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: util.NodePoolLabels(c, np.Name),
@@ -161,7 +162,7 @@ func elasticsearchPodTemplateSpec(controllerName string, c *v1alpha1.Elasticsear
 			Annotations: map[string]string{},
 		},
 		Spec: apiv1.PodSpec{
-			TerminationGracePeriodSeconds: util.Int64Ptr(1800),
+			TerminationGracePeriodSeconds: ptr.Int64(1800),
 			ServiceAccountName:            util.ServiceAccountName(c),
 			NodeSelector:                  np.NodeSelector,
 			SchedulerName:                 np.SchedulerName,

--- a/pkg/controllers/elasticsearch/actions/scale_test.go
+++ b/pkg/controllers/elasticsearch/actions/scale_test.go
@@ -15,6 +15,7 @@ import (
 	testutil "github.com/jetstack/navigator/internal/test/util"
 	"github.com/jetstack/navigator/internal/test/util/generate"
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/util/ptr"
 )
 
 func TestScale(t *testing.T) {
@@ -31,57 +32,57 @@ func TestScale(t *testing.T) {
 	tests := map[string]testT{
 		"should not scale statefulset if documents still remain": {
 			kubeObjects: []runtime.Object{
-				generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+				generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			},
 			navObjects: []runtime.Object{
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-1", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: int64Ptr(2)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-1", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: ptr.Int64(2)}),
 			},
 			cluster:             clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:            nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
 			replicas:            2,
 			shouldUpdate:        false,
-			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			err:                 false,
 		},
 		"should scale statefulset if no documents remain": {
 			kubeObjects: []runtime.Object{
-				generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+				generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			},
 			navObjects: []runtime.Object{
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: int64Ptr(1)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-1", Cluster: "test", NodePool: "data", Documents: int64Ptr(1)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: ptr.Int64(1)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-1", Cluster: "test", NodePool: "data", Documents: ptr.Int64(1)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
 			},
 			cluster:             clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:            nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
 			replicas:            2,
 			shouldUpdate:        true,
-			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(2)}),
+			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(2)}),
 			err:                 false,
 		},
 		"should not scale statefulset if a pilot that should exist is missing": {
 			kubeObjects: []runtime.Object{
-				generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+				generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			},
 			navObjects: []runtime.Object{
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
 			},
 			cluster:             clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:            nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
 			replicas:            2,
 			shouldUpdate:        false,
-			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			err:                 false,
 		},
 		"should not error if statefulset doesn't exist": {
 			kubeObjects: []runtime.Object{},
 			navObjects: []runtime.Object{
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-1", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-1", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
 			},
 			cluster:             clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:            nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
@@ -92,18 +93,18 @@ func TestScale(t *testing.T) {
 		},
 		"should not update if replica difference is zero": {
 			kubeObjects: []runtime.Object{
-				generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+				generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			},
 			navObjects: []runtime.Object{
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-1", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
-				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: int64Ptr(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-0", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-1", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
+				generate.Pilot(generate.PilotConfig{Name: "es-test-data-2", Cluster: "test", NodePool: "data", Documents: ptr.Int64(0)}),
 			},
 			cluster:             clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 3, v1alpha1.ElasticsearchRoleData)),
 			nodePool:            nodePoolPtrWithNameReplicasRoles("data", 3, v1alpha1.ElasticsearchRoleData),
 			replicas:            3,
 			shouldUpdate:        false,
-			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			err:                 false,
 		},
 	}
@@ -174,7 +175,7 @@ func TestPilotsForStatefulSet(t *testing.T) {
 			},
 			cluster:     clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:    nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			expectedPilots: []*v1alpha1.Pilot{
 				pilotWithNameDocuments("es-test-data-0", "test", "data", 10),
 				pilotWithNameDocuments("es-test-data-1", "test", "data", 10),
@@ -188,7 +189,7 @@ func TestPilotsForStatefulSet(t *testing.T) {
 			},
 			cluster:     clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:    nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			err:         true,
 		},
 		{
@@ -202,7 +203,7 @@ func TestPilotsForStatefulSet(t *testing.T) {
 			},
 			cluster:     clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData), nodePoolWithNameReplicasRoles("master", 3, v1alpha1.ElasticsearchRoleMaster)),
 			nodePool:    nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			expectedPilots: []*v1alpha1.Pilot{
 				pilotWithNameDocuments("es-test-data-0", "test", "data", 0),
 				pilotWithNameDocuments("es-test-data-1", "test", "data", 1),
@@ -255,7 +256,7 @@ func TestCanScaleNodePool(t *testing.T) {
 			},
 			cluster:     clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:    nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			replicaDiff: -1,
 			canScale:    true,
 		},
@@ -267,7 +268,7 @@ func TestCanScaleNodePool(t *testing.T) {
 			},
 			cluster:     clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:    nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			replicaDiff: -1,
 			err:         false,
 			canScale:    false,
@@ -280,7 +281,7 @@ func TestCanScaleNodePool(t *testing.T) {
 			},
 			cluster:     clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData)),
 			nodePool:    nodePoolPtrWithNameReplicasRoles("data", 2, v1alpha1.ElasticsearchRoleData),
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			replicaDiff: -1,
 			err:         false,
 			canScale:    false,
@@ -293,7 +294,7 @@ func TestCanScaleNodePool(t *testing.T) {
 			},
 			cluster:     clusterWithNodePools("test", nodePoolWithNameReplicasRoles("data", 4, v1alpha1.ElasticsearchRoleData)),
 			nodePool:    nodePoolPtrWithNameReplicasRoles("data", 4, v1alpha1.ElasticsearchRoleData),
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: int32Ptr(3)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test-data", Replicas: ptr.Int32(3)}),
 			replicaDiff: 1,
 			canScale:    true,
 		},
@@ -347,33 +348,33 @@ func TestDeterminePilotsToBeRemoved(t *testing.T) {
 	tests := map[string]testT{
 		"should only remove highest ordinal pilot in 'test' set": {
 			inputList:      []*v1alpha1.Pilot{pilotWithName("es-test-0"), pilotWithName("es-test-1"), pilotWithName("es-test-2")},
-			statefulSet:    generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: int32Ptr(3)}),
+			statefulSet:    generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: ptr.Int32(3)}),
 			replicaDiff:    -1,
 			expectedOutput: []*v1alpha1.Pilot{pilotWithName("es-test-2")},
 			err:            false,
 		},
 		"should not remove pilot that is not a member of the specified statefulset": {
 			inputList:      []*v1alpha1.Pilot{pilotWithName("es-test-0"), pilotWithName("es-mixed-1"), pilotWithName("es-test-1")},
-			statefulSet:    generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: int32Ptr(2)}),
+			statefulSet:    generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: ptr.Int32(2)}),
 			replicaDiff:    -1,
 			expectedOutput: []*v1alpha1.Pilot{pilotWithName("es-test-1")},
 			err:            false,
 		},
 		"should not remove any pilots if replicaDiff is 0 and highest ordinal pilot is missing": {
 			inputList:   []*v1alpha1.Pilot{pilotWithName("es-test-0")},
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: int32Ptr(2)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: ptr.Int32(2)}),
 			replicaDiff: 0,
 			err:         false,
 		},
 		"should not remove any pilots if replica diff is 0": {
 			inputList:   []*v1alpha1.Pilot{pilotWithName("es-test-0")},
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: int32Ptr(1)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: ptr.Int32(1)}),
 			replicaDiff: 0,
 			err:         false,
 		},
 		"should not remove any pilots of replicaDiff is positive": {
 			inputList:   []*v1alpha1.Pilot{pilotWithName("es-test-0"), pilotWithName("es-test-1")},
-			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: int32Ptr(2)}),
+			statefulSet: generate.StatefulSet(generate.StatefulSetConfig{Name: "es-test", Replicas: ptr.Int32(2)}),
 			replicaDiff: 1,
 			err:         false,
 		},

--- a/pkg/controllers/elasticsearch/actions/update_version_test.go
+++ b/pkg/controllers/elasticsearch/actions/update_version_test.go
@@ -12,16 +12,10 @@ import (
 	"github.com/jetstack/navigator/internal/test/unit/framework"
 	"github.com/jetstack/navigator/internal/test/util/generate"
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/util/ptr"
 )
 
 const esImageRepo = "docker.elastic.co/elasticsearch/elasticsearch"
-
-func int32Ptr(i int32) *int32 {
-	return &i
-}
-func int64Ptr(i int64) *int64 {
-	return &i
-}
 
 func TestUpdateVersion(t *testing.T) {
 	type testT struct {
@@ -38,7 +32,7 @@ func TestUpdateVersion(t *testing.T) {
 			kubeObjects: []runtime.Object{
 				generate.StatefulSet(generate.StatefulSetConfig{
 					Name:            "es-test-data",
-					Replicas:        int32Ptr(3),
+					Replicas:        ptr.Int32(3),
 					Version:         "6.1.1",
 					Image:           esImageRepo + ":6.1.1",
 					CurrentRevision: "a",
@@ -56,12 +50,12 @@ func TestUpdateVersion(t *testing.T) {
 			shouldUpdate: true,
 			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{
 				Name:            "es-test-data",
-				Replicas:        int32Ptr(3),
+				Replicas:        ptr.Int32(3),
 				Version:         "6.1.1",
 				Image:           esImageRepo + ":6.1.2",
 				CurrentRevision: "a",
 				CurrentReplicas: 3,
-				Partition:       int32Ptr(2),
+				Partition:       ptr.Int32(2),
 				ReadyReplicas:   3,
 			}),
 			err: false,
@@ -70,13 +64,13 @@ func TestUpdateVersion(t *testing.T) {
 			kubeObjects: []runtime.Object{
 				generate.StatefulSet(generate.StatefulSetConfig{
 					Name:            "es-test-data",
-					Replicas:        int32Ptr(3),
+					Replicas:        ptr.Int32(3),
 					Version:         "6.1.1",
 					Image:           esImageRepo + ":6.1.2",
 					CurrentRevision: "a",
 					CurrentReplicas: 2,
 					UpdatedReplicas: 1,
-					Partition:       int32Ptr(2),
+					Partition:       ptr.Int32(2),
 					ReadyReplicas:   3,
 				}),
 			},
@@ -96,13 +90,13 @@ func TestUpdateVersion(t *testing.T) {
 			shouldUpdate: true,
 			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{
 				Name:            "es-test-data",
-				Replicas:        int32Ptr(3),
+				Replicas:        ptr.Int32(3),
 				Version:         "6.1.1",
 				Image:           esImageRepo + ":6.1.2",
 				CurrentRevision: "a",
 				CurrentReplicas: 2,
 				UpdatedReplicas: 1,
-				Partition:       int32Ptr(1),
+				Partition:       ptr.Int32(1),
 				ReadyReplicas:   3,
 			}),
 			err: false,
@@ -111,7 +105,7 @@ func TestUpdateVersion(t *testing.T) {
 			kubeObjects: []runtime.Object{
 				generate.StatefulSet(generate.StatefulSetConfig{
 					Name:            "es-test-data",
-					Replicas:        int32Ptr(3),
+					Replicas:        ptr.Int32(3),
 					Version:         "6.1.1",
 					Image:           esImageRepo + ":6.1.1",
 					CurrentRevision: "a",
@@ -139,7 +133,7 @@ func TestUpdateVersion(t *testing.T) {
 			kubeObjects: []runtime.Object{
 				generate.StatefulSet(generate.StatefulSetConfig{
 					Name:            "es-test-data",
-					Replicas:        int32Ptr(3),
+					Replicas:        ptr.Int32(3),
 					Version:         "6.1.1",
 					Image:           esImageRepo + ":6.1.1",
 					CurrentRevision: "a",
@@ -167,13 +161,13 @@ func TestUpdateVersion(t *testing.T) {
 			kubeObjects: []runtime.Object{
 				generate.StatefulSet(generate.StatefulSetConfig{
 					Name:            "es-test-data",
-					Replicas:        int32Ptr(3),
+					Replicas:        ptr.Int32(3),
 					Version:         "6.1.1",
 					Image:           esImageRepo + ":6.1.2",
 					CurrentRevision: "b",
 					UpdateRevision:  "b",
 					CurrentReplicas: 3,
-					Partition:       int32Ptr(2),
+					Partition:       ptr.Int32(2),
 					ReadyReplicas:   3,
 				}),
 			},
@@ -193,13 +187,13 @@ func TestUpdateVersion(t *testing.T) {
 			shouldUpdate: true,
 			expectedStatefulSet: generate.StatefulSet(generate.StatefulSetConfig{
 				Name:            "es-test-data",
-				Replicas:        int32Ptr(3),
+				Replicas:        ptr.Int32(3),
 				Version:         "6.1.2",
 				Image:           esImageRepo + ":6.1.2",
 				CurrentRevision: "b",
 				UpdateRevision:  "b",
 				CurrentReplicas: 3,
-				Partition:       int32Ptr(2),
+				Partition:       ptr.Int32(2),
 				ReadyReplicas:   3,
 			}),
 			err: false,
@@ -208,7 +202,7 @@ func TestUpdateVersion(t *testing.T) {
 			kubeObjects: []runtime.Object{
 				generate.StatefulSet(generate.StatefulSetConfig{
 					Name:            "es-test-data",
-					Replicas:        int32Ptr(3),
+					Replicas:        ptr.Int32(3),
 					Version:         "6.1.1",
 					Image:           esImageRepo + ":6.1.2",
 					CurrentRevision: "a",

--- a/pkg/controllers/elasticsearch/role/controller_test.go
+++ b/pkg/controllers/elasticsearch/role/controller_test.go
@@ -181,5 +181,3 @@ func TestNotControlledByUs(t *testing.T) {
 	// TODO: invent some way to neatly check the status of the 'cluster' after running
 	f.runExpectError(cluster)
 }
-
-func int32Ptr(i int32) *int32 { return &i }

--- a/pkg/controllers/elasticsearch/rolebinding/controller_test.go
+++ b/pkg/controllers/elasticsearch/rolebinding/controller_test.go
@@ -183,5 +183,3 @@ func TestNotControlledByUs(t *testing.T) {
 	// TODO: invent some way to neatly check the status of the 'cluster' after running
 	f.runExpectError(cluster)
 }
-
-func int32Ptr(i int32) *int32 { return &i }

--- a/pkg/controllers/elasticsearch/util/util.go
+++ b/pkg/controllers/elasticsearch/util/util.go
@@ -15,18 +15,6 @@ const (
 	kindName = "ElasticsearchCluster"
 )
 
-func Int32Ptr(i int32) *int32 {
-	return &i
-}
-
-func Int64Ptr(i int64) *int64 {
-	return &i
-}
-
-func BoolPtr(b bool) *bool {
-	return &b
-}
-
 func NewControllerRef(c *v1alpha1.ElasticsearchCluster) metav1.OwnerReference {
 	return *metav1.NewControllerRef(c, schema.GroupVersionKind{
 		Group:   navigator.GroupName,

--- a/pkg/util/ptr/util.go
+++ b/pkg/util/ptr/util.go
@@ -1,0 +1,13 @@
+package ptr
+
+func Int32(i int32) *int32 {
+	return &i
+}
+
+func Int64(i int64) *int64 {
+	return &i
+}
+
+func Bool(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
In https://github.com/jetstack/navigator/pull/256/files#r174153467 @munnerz wrote:
> Maybe it's time to create test/util/pointer to expose these common pointer-related functions for re-use. We've written this function so many times now

**Release note**:
```release-note
NONE
```
