### PR TITLE
Update CassandraCluster.Status.NodePools

### DIFF
--- a/contrib/charts/navigator/templates/rbac.yaml
+++ b/contrib/charts/navigator/templates/rbac.yaml
@@ -87,7 +87,7 @@ items:
     name: "{{ template "fullname" . }}:controller"
   rules:
   - apiGroups: ["navigator.jetstack.io"]
-    resources: ["elasticsearchclusters", "pilots", "elasticsearchclusters/status", "pilots/status", "cassandraclusters"]
+    resources: ["elasticsearchclusters", "pilots", "elasticsearchclusters/status", "pilots/status", "cassandraclusters", "cassandraclusters/status"]
     verbs:     ["*"]
   - apiGroups: [""]
     resources: ["services", "configmaps", "serviceaccounts", "pods"]

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -347,9 +347,9 @@ function test_cassandracluster() {
 
     if ! retry TIMEOUT=300 stdout_equals 2 kubectl \
          --namespace "${namespace}" \
-         get statefulsets \
-         "cass-${CASS_NAME}-ringnodes" \
-         "-o=go-template={{.status.readyReplicas}}"
+         get cassandracluster \
+         "${CASS_NAME}" \
+         "-o=jsonpath={ .status.nodePools['ringnodes'].readyReplicas }"
     then
         fail_test "Second cassandra node did not become ready"
     fi

--- a/pkg/controllers/cassandra/nodepool/nodepool.go
+++ b/pkg/controllers/cassandra/nodepool/nodepool.go
@@ -6,7 +6,10 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1beta1"
 	"k8s.io/client-go/tools/record"
 
+	"github.com/golang/glog"
+
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 )
 
 type Interface interface {
@@ -68,6 +71,28 @@ func (e *defaultCassandraClusterNodepoolControl) Sync(cluster *v1alpha1.Cassandr
 		if err != nil {
 			return err
 		}
+	}
+	return e.updateStatus(cluster)
+}
+
+func (e *defaultCassandraClusterNodepoolControl) updateStatus(cluster *v1alpha1.CassandraCluster) error {
+	cluster.Status.NodePools = map[string]v1alpha1.CassandraClusterNodePoolStatus{}
+	sets, err := util.StatefulSetsForCluster(cluster, e.statefulSetLister)
+	if err != nil {
+		return err
+	}
+	// Create a NodePoolStatus for each statefulset that is controlled by this cluster.
+	for ssName, ss := range sets {
+		clusterName, npName, err := util.ParseNodePoolResourceName(ssName)
+		if err != nil {
+			glog.Errorf("Error parsing statefulset name: %s", err)
+		}
+		if clusterName != cluster.Name {
+			glog.Errorf("statefulset name %q did not contain cluster name %q", ssName, cluster.Name)
+		}
+		nps := cluster.Status.NodePools[npName]
+		nps.ReadyReplicas = ss.Status.ReadyReplicas
+		cluster.Status.NodePools[npName] = nps
 	}
 	return nil
 }

--- a/pkg/controllers/cassandra/util/util.go
+++ b/pkg/controllers/cassandra/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/api/apps/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +36,27 @@ func ResourceBaseName(c *v1alpha1.CassandraCluster) string {
 
 func NodePoolResourceName(c *v1alpha1.CassandraCluster, np *v1alpha1.CassandraClusterNodePool) string {
 	return fmt.Sprintf("%s-%s", ResourceBaseName(c), np.Name)
+}
+
+func ParseNodePoolResourceName(name string) (string, string, error) {
+	err := fmt.Errorf(
+		"not a NodePool statefulset name. "+
+			"Expected 'cass-<clustername>-<nodepoolname>'. "+
+			"Got %q.",
+		name,
+	)
+	parts := strings.Split(name, "-")
+	partsCount := len(parts)
+	if partsCount < 3 {
+		return "", "", err
+	}
+	if parts[0] != typeName {
+		return "", "", err
+	}
+	clusterName := strings.Join(parts[1:len(parts)-1], "-")
+	nodePoolName := parts[len(parts)-1]
+
+	return clusterName, nodePoolName, nil
 }
 
 func SeedsServiceName(c *v1alpha1.CassandraCluster) string {


### PR DESCRIPTION
* Ensure that `CassandraCluster.Status.NodePools` contains the status of all the statefulsets controlled by the cluster.

Extracted from: #256 
Part of: #253 

**Release note**:
```release-note
NONE
```
