### PR TITLE
Improve development docs and add Development Cycles document

### DIFF
--- a/docs/devel/development-cycles.rst
+++ b/docs/devel/development-cycles.rst
@@ -1,0 +1,39 @@
+==================
+Development cycles
+==================
+
+Navigator is currently under heavy development, and so has quite a fast paced
+release cycle.
+
+We aim to cut a new minor release once a month, somewhere around the end of each month.
+
+A development cycle should look something like:
+
+
+Dates
+=====
+
+* **18/03/31** - new minor release cut
+
+* **18/04/01** - master accepting PRs targetted at the next minor release
+
+* **18/04/15** - Release branch is made and `-alpha.1` version of the next
+  minor release is cut. Until the end of the month, only PRs approved for the
+  current milestone will be accepted.
+
+* **18/04/15 until 31st** - new alpha releases are cut if neccessary. The
+  release branch will be fast forwarded to HEAD of master and tagged accordingly.
+
+* **18/04/31** - New minor release tag is cut.
+
+The cycle then repeats each month.
+
+Bugfixes and patch versions
+===========================
+
+Critical bugfixes will be cherry picked into the previous release branch **only**.
+New patch versions will then be cut as required. If this informal method of
+releasing patch versions becomes problematic, we may review our patching policy.
+
+This allows us to maintain a strong development velocity, whilst also
+providing a basic layer of support for users so we can gather feedback.

--- a/docs/devel/getting-started.rst
+++ b/docs/devel/getting-started.rst
@@ -1,8 +1,14 @@
-Development guide
-=================
+===============
+Getting started
+===============
 
-Setting up
-----------
+This guide runs you through getting started developing Navigator using minikube.
+
+It sets up a local minikube cluster, and explains how to build and deploy your
+custom built images for Navigator.
+
+Setting up minikube
+===================
 
 Install minikube and start a cluster with RBAC enabled::
 
@@ -47,7 +53,7 @@ and set the ``pullPolicy`` to ``Never``, then create the cluster::
 
 
 Developing
-----------
+==========
 
 Edit code, then build::
 

--- a/docs/devel/index.rst
+++ b/docs/devel/index.rst
@@ -1,0 +1,13 @@
+=================
+Development guide
+=================
+
+This is the Navigator development documentation. These documents are targetted
+at those that want to develop Navigator itself, and not end users.
+
+.. toctree::
+   :maxdepth: 2
+
+   getting-started
+   updating-apis
+   development-cycles

--- a/docs/devel/updating-apis.rst
+++ b/docs/devel/updating-apis.rst
@@ -1,0 +1,68 @@
+==================
+Updating API types
+==================
+
+When updating API types, it's important to follow a protocol to ensure changes
+are communicated clearly to users and all components support the new types
+properly.
+
+All PRs changing API types **require** a release note
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+PRs that touch API types should have a release note that clearly describes the
+change, e.g:
+
+.. code-block:: none
+
+   ```release-note
+   Added 'spec.minimumMasters' field to ElasticsearchCluster
+   ```
+
+All non-trivial fields should have a comment describing new fields/types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Following godoc conventions allows us to generate API reference documentation
+and publish information via swagger. All types and fields should have some form
+of description in the form of a comment.
+
+Run hack/update-client-gen.sh to regenerate clients etc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This step should also be enforced by CI testing. This will ensure deepcopies,
+conversions, clientsets and informers are up to date. There is a script in
+`hack/` that can be used:
+
+.. code-block:: shell
+
+    $ ./hack/update-client-gen.sh
+    Generating deepcopy funcs
+    Generating defaulters
+    Generating clientset for navigator:v1alpha1 at github.com/jetstack/navigator/pkg/client/clientset
+    Generating listers for navigator:v1alpha1 at github.com/jetstack/navigator/pkg/client/listers
+    Generating informers for navigator:v1alpha1 at github.com/jetstack/navigator/pkg/client/informers
+    Generating conversions
+
+New functionality should be implemented with *fields* not annotations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If adding new functionality that is considered experimental or alpha to a beta
+or stable API, add a new field to the resource and explicitly call out the
+status of the field in its godoc:
+
+.. code-block:: go
+   :linenos:
+
+   type FooCluster struct {
+       ...
+       // Replicas is the number of Foo cluster nodes to be created
+       Replicas int64 `json:"replicas"`
+
+       // EXPERIMENTAL: use of this field is considered experimental
+       // TLS specifies the TLS configuration to use for the nodes in the Foo
+       // cluster. If not specified, the cluster will be configured for insecure
+       // connections.
+       TLS *FooTLSConfig `json:"tls"`
+   }
+
+This provides type-safety and a mechanism for validation, as well as versioning
+without extra complexity when promoting an old annotation to a field.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ or otherwise update the Navigator API with details of the failure so that naviga
    quick-start
    elasticsearch
    cassandra
-   developing
+   devel/index
 
 
 Indices and tables


### PR DESCRIPTION
**What this PR does / why we need it**:

Breaks out the development docs from a single rst file, and adds two new documents:

* Development Cycles - to document how we develop through the month in relation to releases
* Updating API types - information on how to change API types (i.e. regenerating code etc)

**Special notes for your reviewer**:

I've had the updating API types doc locally for quite a while, so I updated it to rst and including it with this PR 😄

**Release note**:
```release-note
Improve development documentation
```
