### PR TITLE
Identify statefulsets by labels rather than error prone name parsing

### DIFF
--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   version: "3.11.1"
   nodePools:
-  - name: "ringnodes"
+  - name: "region-1-zone-a"
     replicas: 3
-    datacenter: "demo-datacenter"
-    rack: "demo-rack"
+    datacenter: "region-1"
+    rack: "zone-a"
     persistence:
       enabled: true
       size: "5Gi"

--- a/hack/testdata/cass-cluster-test.template.yaml
+++ b/hack/testdata/cass-cluster-test.template.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   version: "${CASS_VERSION}"
   nodePools:
-  - name: "region-1-zone-a"
+  - name: "${CASS_NODEPOOL1_NAME}"
     replicas: ${CASS_REPLICAS}
-    datacenter: "region-1"
-    rack: "zone-a"
+    datacenter: "${CASS_NODEPOOL1_DATACENTER}"
+    rack: "${CASS_NODEPOOL1_RACK}"
     persistence:
       enabled: true
       size: "5Gi"

--- a/hack/testdata/cass-cluster-test.template.yaml
+++ b/hack/testdata/cass-cluster-test.template.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   version: "${CASS_VERSION}"
   nodePools:
-  - name: "ringnodes"
+  - name: "region-1-zone-a"
     replicas: ${CASS_REPLICAS}
-    datacenter: "${CASS_NAME}-datacenter"
-    rack: "{CASS_NAME}-rack"
+    datacenter: "region-1"
+    rack: "zone-a"
     persistence:
       enabled: true
       size: "5Gi"

--- a/pkg/controllers/cassandra/nodepool/nodepool.go
+++ b/pkg/controllers/cassandra/nodepool/nodepool.go
@@ -5,8 +5,6 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1beta1"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/golang/glog"
-
 	v1alpha1 "github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
 )
@@ -46,14 +44,8 @@ func (e *defaultCassandraClusterNodepoolControl) updateStatus(cluster *v1alpha1.
 		return err
 	}
 	// Create a NodePoolStatus for each statefulset that is controlled by this cluster.
-	for ssName, ss := range sets {
-		clusterName, npName, err := util.ParseNodePoolResourceName(ssName)
-		if err != nil {
-			glog.Errorf("Error parsing statefulset name: %s", err)
-		}
-		if clusterName != cluster.Name {
-			glog.Errorf("statefulset name %q did not contain cluster name %q", ssName, cluster.Name)
-		}
+	for _, ss := range sets {
+		npName := ss.Labels[util.NodePoolNameLabelKey]
 		nps := cluster.Status.NodePools[npName]
 		nps.ReadyReplicas = ss.Status.ReadyReplicas
 		cluster.Status.NodePools[npName] = nps

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -43,7 +43,7 @@ func StatefulSetForCluster(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            statefulSetName,
 			Namespace:       cluster.Namespace,
-			Labels:          util.ClusterLabels(cluster),
+			Labels:          nodePoolLabels,
 			Annotations:     make(map[string]string),
 			OwnerReferences: []metav1.OwnerReference{util.NewControllerRef(cluster)},
 		},

--- a/pkg/controllers/cassandra/seedlabeller/control_test.go
+++ b/pkg/controllers/cassandra/seedlabeller/control_test.go
@@ -1,6 +1,7 @@
 package seedlabeller_test
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -35,7 +36,7 @@ func TestSeedLabellerSync(t *testing.T) {
 	ss0 := nodepool.StatefulSetForCluster(cluster, np0)
 	pod0 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cass-cassandra-1-RingNodes-0",
+			Name:      fmt.Sprintf("%s-0", ss0.Name),
 			Namespace: cluster.Namespace,
 		},
 	}

--- a/pkg/controllers/cassandra/testing/testing.go
+++ b/pkg/controllers/cassandra/testing/testing.go
@@ -36,7 +36,7 @@ func ClusterForTest() *v1alpha1.CassandraCluster {
 		Spec: v1alpha1.CassandraClusterSpec{
 			NodePools: []v1alpha1.CassandraClusterNodePool{
 				v1alpha1.CassandraClusterNodePool{
-					Name:     "RingNodes",
+					Name:     "region-1-zone-a",
 					Replicas: 3,
 				},
 			},

--- a/pkg/controllers/cassandra/util/util.go
+++ b/pkg/controllers/cassandra/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/api/apps/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,27 +35,6 @@ func ResourceBaseName(c *v1alpha1.CassandraCluster) string {
 
 func NodePoolResourceName(c *v1alpha1.CassandraCluster, np *v1alpha1.CassandraClusterNodePool) string {
 	return fmt.Sprintf("%s-%s", ResourceBaseName(c), np.Name)
-}
-
-func ParseNodePoolResourceName(name string) (string, string, error) {
-	err := fmt.Errorf(
-		"not a NodePool statefulset name. "+
-			"Expected 'cass-<clustername>-<nodepoolname>'. "+
-			"Got %q.",
-		name,
-	)
-	parts := strings.Split(name, "-")
-	partsCount := len(parts)
-	if partsCount < 3 {
-		return "", "", err
-	}
-	if parts[0] != typeName {
-		return "", "", err
-	}
-	clusterName := strings.Join(parts[1:len(parts)-1], "-")
-	nodePoolName := parts[len(parts)-1]
-
-	return clusterName, nodePoolName, nil
 }
 
 func SeedsServiceName(c *v1alpha1.CassandraCluster) string {


### PR DESCRIPTION
* Ensure that nodepool name label is added to the statefulsets created for each nodepool
* Use that label when creating nodepool status for each statefulset (rather than attempting to parse the ss name)
* Use more realistic nodepool names (including dashes) in the docs and in the tests.

Fixes: #304 

**Release note**:
```release-note
NONE
```
