### PR TITLE
Work around for helm hanging in prepare-e2e.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ all: verify build docker_build
 test: go_test
 
 .run_e2e:
-	${HACK_DIR}/prepare-e2e.sh; \
+	${HACK_DIR}/prepare-e2e.sh
 	${HACK_DIR}/e2e.sh
 
 e2e-test: build docker_build .run_e2e

--- a/hack/prepare-e2e.sh
+++ b/hack/prepare-e2e.sh
@@ -37,7 +37,9 @@ EOF
 helm init --service-account=tiller
 
 echo "Waiting for tiller to be ready..."
-retry TIMEOUT=60 helm version
+# helm sometimes hangs so we wrap it with a timeout in addition to retrying
+# See https://github.com/jetstack/navigator/issues/314
+retry TIMEOUT=300 timeout 60 helm version
 
 echo "Applying Elasticsearch virtual memory configuration on all nodes..."
 # See https://www.elastic.co/guide/en/elasticsearch/reference/current/system-config.html


### PR DESCRIPTION
* Make sure that E2E tests exit early if the `prepare-e2e.sh` script fails.
* Add a hard timeout when calling `helm version` in the prepare-e2e.sh script and retry for longer.

Fixes: #314 

**Release note**:
```release-note
NONE
```
