### PR TITLE
Add validation to only allow Cassandra major version 3

### DIFF
--- a/docs/cassandra.rst
+++ b/docs/cassandra.rst
@@ -228,3 +228,8 @@ Scale Out
 When you first create a cluster or when you increment the ``CassandraCluster.Spec.NodePools[i].ReplicaCount``,
 Navigator will add C* nodes, one at a time, until the desired number of nodes is reached.
 You can look at ``CassandraCluster.Status.NodePools[<nodepoolname>].ReadyReplicas`` to see the current number of healthy C* nodes in each ``nodepool``.
+
+Supported Versions
+------------------
+
+Navigator only supports Cassandra major version 3.

--- a/pkg/cassandra/version/version.go
+++ b/pkg/cassandra/version/version.go
@@ -108,3 +108,23 @@ var _ json.Marshaler = &Version{}
 func (v Version) Semver() string {
 	return v.semver.String()
 }
+
+func (v *Version) BumpPatch() *Version {
+	sv := semver.New(v.Semver())
+	sv.BumpPatch()
+	return New(sv.String())
+}
+func (v *Version) BumpMinor() *Version {
+	sv := semver.New(v.Semver())
+	sv.BumpMinor()
+	return New(sv.String())
+}
+func (v *Version) BumpMajor() *Version {
+	sv := semver.New(v.Semver())
+	sv.BumpMajor()
+	return New(sv.String())
+}
+
+func (v *Version) LessThan(versionB *Version) bool {
+	return v.semver.LessThan(versionB.semver)
+}


### PR DESCRIPTION
* Only allow versions >= 3.0.0 && < 4.0.0
* Disallow version changes in API updates (pending #277)
* Document the supported versions.

Fixes: #320
**Release note**:
```release-note
NONE
```
