### PR TITLE
Delete left over pilots

### DIFF
--- a/pkg/apis/navigator/v1alpha1/types.go
+++ b/pkg/apis/navigator/v1alpha1/types.go
@@ -15,8 +15,9 @@ const (
 	ElasticsearchNodePoolVersionAnnotation = "navigator.jetstack.io/elasticsearch-version"
 	ElasticsearchRoleLabelPrefix           = "navigator.jetstack.io/elasticsearch-role-"
 
-	CassandraClusterNameLabel  = "navigator.jetstack.io/cassandra-cluster-name"
-	CassandraNodePoolNameLabel = "navigator.jetstack.io/cassandra-node-pool-name"
+	CassandraClusterNameLabel   = "navigator.jetstack.io/cassandra-cluster-name"
+	CassandraNodePoolNameLabel  = "navigator.jetstack.io/cassandra-node-pool-name"
+	CassandraNodePoolIndexLabel = "navigator.jetstack.io/cassandra-node-pool-index"
 )
 
 // +genclient

--- a/pkg/controllers/cassandra/pilot/pilot.go
+++ b/pkg/controllers/cassandra/pilot/pilot.go
@@ -93,7 +93,7 @@ func (c *pilotControl) Sync(cluster *v1alpha1.CassandraCluster) error {
 }
 
 func PilotForCluster(cluster *v1alpha1.CassandraCluster, pod *v1.Pod) *v1alpha1.Pilot {
-	return &v1alpha1.Pilot{
+	o := &v1alpha1.Pilot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            pod.Name,
 			Namespace:       pod.Namespace,
@@ -101,4 +101,6 @@ func PilotForCluster(cluster *v1alpha1.CassandraCluster, pod *v1.Pod) *v1alpha1.
 			OwnerReferences: []metav1.OwnerReference{util.NewControllerRef(cluster)},
 		},
 	}
+	o.Labels[v1alpha1.CassandraNodePoolNameLabel] = pod.Labels[v1alpha1.CassandraNodePoolNameLabel]
+	return o
 }

--- a/pkg/controllers/cassandra/pilot/pilot_test.go
+++ b/pkg/controllers/cassandra/pilot/pilot_test.go
@@ -1,8 +1,10 @@
 package pilot_test
 
 import (
+	"fmt"
 	"testing"
 
+	"k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,18 +15,19 @@ import (
 	"github.com/jetstack/navigator/internal/test/unit/framework"
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/controllers/cassandra/nodepool"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/pilot"
 	casstesting "github.com/jetstack/navigator/pkg/controllers/cassandra/testing"
 )
 
-func clusterPod(cluster *v1alpha1.CassandraCluster, name, nodePoolName string) *v1.Pod {
+func clusterPod(cluster *v1alpha1.CassandraCluster, set *v1beta1.StatefulSet, index int32) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: cluster.Namespace,
+			Name:      fmt.Sprintf("%s-%d", set.Name, index),
+			Namespace: set.Namespace,
 			Labels: map[string]string{
 				v1alpha1.CassandraClusterNameLabel:  cluster.Name,
-				v1alpha1.CassandraNodePoolNameLabel: nodePoolName,
+				v1alpha1.CassandraNodePoolNameLabel: set.Labels[v1alpha1.CassandraNodePoolNameLabel],
 			},
 		},
 	}
@@ -32,16 +35,22 @@ func clusterPod(cluster *v1alpha1.CassandraCluster, name, nodePoolName string) *
 
 func TestPilotSync(t *testing.T) {
 	cluster1 := casstesting.ClusterForTest()
-	cluster1pod1 := clusterPod(cluster1, "c1p1", "np-1")
-	cluster1pod2 := clusterPod(cluster1, "c1p2", "np-1")
-	cluster1pilot1 := pilot.PilotForCluster(cluster1, cluster1pod1)
-	cluster1pilot1foreign := cluster1pilot1.DeepCopy()
-	cluster1pilot1foreign.SetOwnerReferences([]metav1.OwnerReference{})
+	cluster1np1 := &cluster1.Spec.NodePools[0]
+	cluster1np1set := nodepool.StatefulSetForCluster(cluster1, cluster1np1)
+	cluster1np1set.Status.CurrentReplicas = 1
+	cluster1np1pod0 := clusterPod(cluster1, cluster1np1set, 0)
+	cluster1np1pod1 := clusterPod(cluster1, cluster1np1set, 1)
+	cluster1np1pilot0 := pilot.PilotForCluster(cluster1, cluster1np1pod0)
+	cluster1np1pilot1 := pilot.PilotForCluster(cluster1, cluster1np1pod1)
+	cluster1np1pilot0foreign := cluster1np1pilot0.DeepCopy()
+	cluster1np1pilot0foreign.SetOwnerReferences([]metav1.OwnerReference{})
 
 	cluster2 := casstesting.ClusterForTest()
 	cluster2.SetName("cluster2")
 	cluster2.SetUID("uid2")
-	cluster2pod1 := clusterPod(cluster2, "c2p1", "np-1")
+	cluster2np1 := &cluster2.Spec.NodePools[0]
+	cluster2np1set := nodepool.StatefulSetForCluster(cluster2, cluster2np1)
+	cluster2np1pod0 := clusterPod(cluster2, cluster2np1set, 0)
 
 	type testT struct {
 		kubeObjects []runtime.Object
@@ -54,9 +63,11 @@ func TestPilotSync(t *testing.T) {
 	tests := map[string]testT{
 		"each cluster pod gets a pilot": {
 			kubeObjects: []runtime.Object{
-				cluster1pod1,
-				cluster1pod2,
-				cluster2pod1,
+				cluster1np1set,
+				cluster1np1pod0,
+				cluster1np1pod1,
+				cluster2np1set,
+				cluster2np1pod0,
 			},
 			cluster: cluster1,
 			assertions: func(t *testing.T, state *controllers.State) {
@@ -75,8 +86,10 @@ func TestPilotSync(t *testing.T) {
 		},
 		"non-cluster pods are ignored": {
 			kubeObjects: []runtime.Object{
-				cluster1pod1,
-				cluster2pod1,
+				cluster1np1set,
+				cluster1np1pod0,
+				cluster2np1set,
+				cluster2np1pod0,
 			},
 			cluster: cluster1,
 			assertions: func(t *testing.T, state *controllers.State) {
@@ -94,15 +107,67 @@ func TestPilotSync(t *testing.T) {
 			},
 		},
 		"no error if pilot exists": {
-			kubeObjects: []runtime.Object{cluster1pod1},
-			navObjects:  []runtime.Object{cluster1pilot1},
-			cluster:     cluster1,
+			kubeObjects: []runtime.Object{
+				cluster1np1set,
+				cluster1np1pod0,
+			},
+			navObjects: []runtime.Object{cluster1np1pilot0},
+			cluster:    cluster1,
 		},
 		"error if foreign owned": {
-			kubeObjects: []runtime.Object{cluster1pod1},
-			navObjects:  []runtime.Object{cluster1pilot1foreign},
+			kubeObjects: []runtime.Object{cluster1np1pod0},
+			navObjects:  []runtime.Object{cluster1np1pilot0foreign},
 			cluster:     cluster1,
 			expectErr:   true,
+		},
+		"do not delete if pod exists": {
+			kubeObjects: []runtime.Object{
+				cluster1np1set,
+				cluster1np1pod0,
+				cluster1np1pod1,
+			},
+			navObjects: []runtime.Object{
+				cluster1np1pilot0,
+				cluster1np1pilot1,
+			},
+			cluster: cluster1,
+			assertions: func(t *testing.T, state *controllers.State) {
+				pilots, err := state.NavigatorClientset.
+					Navigator().Pilots(cluster1.Namespace).List(metav1.ListOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedPilotCount := 2
+				pilotCount := len(pilots.Items)
+				if pilotCount != expectedPilotCount {
+					t.Log(pretty.Sprint(pilots))
+					t.Errorf("Unexpected pilot count: %d != %d", expectedPilotCount, pilotCount)
+				}
+			},
+		},
+		"pilot deleted": {
+			kubeObjects: []runtime.Object{
+				cluster1np1set,
+				cluster1np1pod0,
+			},
+			navObjects: []runtime.Object{
+				cluster1np1pilot0,
+				cluster1np1pilot1,
+			},
+			cluster: cluster1,
+			assertions: func(t *testing.T, state *controllers.State) {
+				pilots, err := state.NavigatorClientset.
+					Navigator().Pilots(cluster1.Namespace).List(metav1.ListOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedPilotCount := 1
+				pilotCount := len(pilots.Items)
+				if pilotCount != expectedPilotCount {
+					t.Log(pretty.Sprint(pilots))
+					t.Errorf("Unexpected pilot count: %d != %d", expectedPilotCount, pilotCount)
+				}
+			},
 		},
 	}
 	for title, test := range tests {


### PR DESCRIPTION
Contrary to the original idea of creating pilots during scale-out and deleting them during scale-in,
I've instead extended the existing pilot sync method to delete pilots with an index higher than the CurrentReplicas value of the corresponding StatefulSet.
And I modified the pilot creation logic to select pods based on labels rather than based on cluster > statefulset ownership.

Fixes: #322

**Release note**:
```release-note
NONE
```
