### PR TITLE
Use ordered pod management

### DIFF
--- a/docs/cassandra.rst
+++ b/docs/cassandra.rst
@@ -227,4 +227,13 @@ Scale Out
 
 When you first create a cluster or when you increment the ``CassandraCluster.Spec.NodePools[i].ReplicaCount``,
 Navigator will add C* nodes, one at a time, until the desired number of nodes is reached.
+
+.. note::
+
+   Navigator adds C* Nodes in series (one-at-a-time)
+   and it configures all C* nodes with `auto_bootstrap: true <https://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__auto_bootstrap>`_.
+   These settings are chosen based on current best practice for Cassandra v3, described in the the following documents:
+   `Bootstrapping Apache Cassandra Nodes <http://thelastpickle.com/blog/2017/05/23/auto-bootstrapping-part1.html>`_
+   and `Best way to add multiple nodes to existing cassandra cluster <https://stackoverflow.com/questions/37283424/best-way-to-add-multiple-nodes-to-existing-cassandra-cluster>`_.
+
 You can look at ``CassandraCluster.Status.NodePools[<nodepoolname>].ReadyReplicas`` to see the current number of healthy C* nodes in each ``nodepool``.

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -55,7 +55,7 @@ func StatefulSetForCluster(
 			UpdateStrategy: apps.StatefulSetUpdateStrategy{
 				Type: apps.RollingUpdateStatefulSetStrategyType,
 			},
-			PodManagementPolicy: apps.ParallelPodManagement,
+			PodManagementPolicy: apps.OrderedReadyPodManagement,
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: nodePoolLabels,


### PR DESCRIPTION
Our ScaleOut action already adds pods one-at-a-time, but using the parallel management policy in the statefulset was definitely wrong.

**Release note**:
```release-note
NONE
```
