### PR TITLE
Use the pure Java kubernetes-seedprovider

### DIFF
--- a/Dockerfile.pilot-cassandra
+++ b/Dockerfile.pilot-cassandra
@@ -9,7 +9,8 @@ RUN chmod a+r /jmx_prometheus_javaagent.jar && touch /jmx_prometheus_javaagent.j
 RUN chmod a+r /jmx_prometheus_javaagent.yaml && touch /jmx_prometheus_javaagent.yaml
 
 # note: temporarily pulled directly from kubernetes/examples until we find a better place to put it
-ADD https://github.com/kubernetes/examples/raw/master/cassandra/image/files/kubernetes-cassandra.jar /kubernetes-cassandra.jar
+# Use the commit before https://github.com/kubernetes/examples/pull/201, because that broke everything.
+ADD https://github.com/kubernetes/examples/raw/7ac4ceb28b98b78c5be337a141c2db10b862e31e/cassandra/image/files/kubernetes-cassandra.jar /kubernetes-cassandra.jar
 RUN chmod a+r /kubernetes-cassandra.jar && touch /kubernetes-cassandra.jar
 
 ADD navigator-pilot-cassandra_linux_amd64 /pilot


### PR DESCRIPTION
* from before https://github.com/kubernetes/examples/pull/201
* because that introduced a new Go / CGo shared library dependency which we don't want to have to bundle into our pilot image.

**Release note**:
```release-note
NONE
```
