### PR TITLE
Change cassandra seed provider to jetstack/cassandra-kubernetes-seed-provider

### DIFF
--- a/Dockerfile.pilot-cassandra
+++ b/Dockerfile.pilot-cassandra
@@ -8,10 +8,8 @@ RUN chmod a+r /jolokia.jar && touch /jolokia.jar
 RUN chmod a+r /jmx_prometheus_javaagent.jar && touch /jmx_prometheus_javaagent.jar
 RUN chmod a+r /jmx_prometheus_javaagent.yaml && touch /jmx_prometheus_javaagent.yaml
 
-# note: temporarily pulled directly from kubernetes/examples until we find a better place to put it
-# Use the commit before https://github.com/kubernetes/examples/pull/201, because that broke everything.
-ADD https://github.com/kubernetes/examples/raw/7ac4ceb28b98b78c5be337a141c2db10b862e31e/cassandra/image/files/kubernetes-cassandra.jar /kubernetes-cassandra.jar
-RUN chmod a+r /kubernetes-cassandra.jar && touch /kubernetes-cassandra.jar
+ADD https://github.com/jetstack/cassandra-kubernetes-seed-provider/releases/download/0.1.0/libcassandra-kubernetes-seed-provider.jar /libcassandra-kubernetes-seed-provider.jar
+RUN chmod a+r /libcassandra-kubernetes-seed-provider.jar && touch /libcassandra-kubernetes-seed-provider.jar
 
 ADD navigator-pilot-cassandra_linux_amd64 /pilot
 

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -231,7 +231,7 @@ func StatefulSetForCluster(
 									Name: "CLASSPATH",
 									Value: path.Join(
 										sharedVolumeMountPath,
-										"kubernetes-cassandra.jar",
+										"libcassandra-kubernetes-seed-provider.jar",
 									),
 								},
 								{
@@ -326,7 +326,7 @@ func pilotInstallationContainer(
 			"/jolokia.jar",
 			"/jmx_prometheus_javaagent.jar",
 			"/jmx_prometheus_javaagent.yaml",
-			"/kubernetes-cassandra.jar",
+			"/libcassandra-kubernetes-seed-provider.jar",
 			fmt.Sprintf("%s/", sharedVolumeMountPath),
 		},
 		VolumeMounts: []apiv1.VolumeMount{

--- a/pkg/pilot/cassandra/v3/pilot.go
+++ b/pkg/pilot/cassandra/v3/pilot.go
@@ -53,7 +53,7 @@ func NewPilot(opts *PilotOptions) (*Pilot, error) {
 
 	newContents := strings.Replace(string(read),
 		"org.apache.cassandra.locator.SimpleSeedProvider",
-		"io.k8s.cassandra.KubernetesSeedProvider", -1)
+		"io.jetstack.cassandra.KubernetesSeedProvider", -1)
 
 	err = ioutil.WriteFile(cfgPath, []byte(newContents), 0)
 	if err != nil {


### PR DESCRIPTION
This switches cassandra to use https://github.com/jetstack/cassandra-kubernetes-seed-provider, which is a fork of the seed provider from kubernetes/examples.

```release-note
Change cassandra seed provider to jetstack/cassandra-kubernetes-seed-provider
```
