### PR TITLE
Use cgroup for jvm memory limit

### DIFF
--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -218,7 +218,16 @@ func StatefulSetForCluster(
 									Name: "JVM_OPTS",
 									Value: fmt.Sprintf(
 										"-javaagent:%s/jolokia.jar=host=%s,port=%d,agentContext=%s "+
-											"-javaagent:%s/jmx_prometheus_javaagent.jar=8080:%s/jmx_prometheus_javaagent.yaml",
+											"-javaagent:%s/jmx_prometheus_javaagent.jar=8080:%s/jmx_prometheus_javaagent.yaml "+
+
+											// allow using cgroup flags
+											"-XX:+UnlockExperimentalVMOptions "+
+
+											// use cgroup limit instead of host
+											"-XX:+UseCGroupMemoryLimitForHeap "+
+
+											// use 100% of the available memory
+											"-XX:MaxRAMFraction=1 ",
 										sharedVolumeMountPath,
 										jolokiaHost,
 										jolokiaPort,

--- a/pkg/controllers/cassandra/nodepool/resource.go
+++ b/pkg/controllers/cassandra/nodepool/resource.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers/cassandra/util"
+	"github.com/jetstack/navigator/pkg/controllers/common"
 	"github.com/jetstack/navigator/pkg/util/ptr"
 )
 
@@ -219,15 +220,7 @@ func StatefulSetForCluster(
 									Value: fmt.Sprintf(
 										"-javaagent:%s/jolokia.jar=host=%s,port=%d,agentContext=%s "+
 											"-javaagent:%s/jmx_prometheus_javaagent.jar=8080:%s/jmx_prometheus_javaagent.yaml "+
-
-											// allow using cgroup flags
-											"-XX:+UnlockExperimentalVMOptions "+
-
-											// use cgroup limit instead of host
-											"-XX:+UseCGroupMemoryLimitForHeap "+
-
-											// use 100% of the available memory
-											"-XX:MaxRAMFraction=1 ",
+											common.JVMCgroupOpts,
 										sharedVolumeMountPath,
 										jolokiaHost,
 										jolokiaPort,

--- a/pkg/controllers/common/common.go
+++ b/pkg/controllers/common/common.go
@@ -1,0 +1,13 @@
+package common
+
+const (
+	JVMCgroupOpts =
+	// allow using cgroup flags
+	"-XX:+UnlockExperimentalVMOptions " +
+
+		// use cgroup limit instead of host
+		"-XX:+UseCGroupMemoryLimitForHeap " +
+
+		// use 100% of the available memory
+		"-XX:MaxRAMFraction=1 "
+)

--- a/pkg/controllers/elasticsearch/actions/create_nodepool.go
+++ b/pkg/controllers/elasticsearch/actions/create_nodepool.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jetstack/navigator/pkg/apis/navigator/v1alpha1"
 	"github.com/jetstack/navigator/pkg/controllers"
+	"github.com/jetstack/navigator/pkg/controllers/common"
 	"github.com/jetstack/navigator/pkg/controllers/elasticsearch/util"
 	"github.com/jetstack/navigator/pkg/util/ptr"
 )
@@ -199,6 +200,10 @@ func elasticsearchPodTemplateSpec(controllerName string, c *v1alpha1.Elasticsear
 						{
 							Name:  "PLUGINS",
 							Value: plugins,
+						},
+						{
+							Name:  "ES_JAVA_OPTS",
+							Value: common.JVMCgroupOpts,
 						},
 						{
 							Name: "LEADER_ELECTION_CONFIG_MAP",


### PR DESCRIPTION
This should cap memory limits to the amount allocated in the containers cgroup.

```release-note
Use cgroup for jvm memory limit
```
