### PR TITLE
Bump version numbers for v0.1.0

### DIFF
--- a/contrib/charts/navigator/values.yaml
+++ b/contrib/charts/navigator/values.yaml
@@ -22,7 +22,7 @@ apiserver:
   # serviceAccount: "apiserver-svc-acct"
   image:
     repository: quay.io/jetstack/navigator-apiserver
-    tag: v0.1.0-alpha.1
+    tag: v0.1.0
     pullPolicy: Always
   logLevel: 2
 
@@ -42,7 +42,7 @@ controller:
   # serviceAccount: "controller-svc-acct"
   image:
     repository: quay.io/jetstack/navigator-controller
-    tag: v0.1.0-alpha.1
+    tag: v0.1.0
     pullPolicy: Always
   logLevel: 2
 

--- a/docs/quick-start/cassandra-cluster.yaml
+++ b/docs/quick-start/cassandra-cluster.yaml
@@ -27,4 +27,4 @@ spec:
     pullPolicy: "IfNotPresent"
   pilotImage:
     repository: "quay.io/jetstack/navigator-pilot-cassandra"
-    tag: "v0.1.0-alpha.1"
+    tag: "v0.1.0"

--- a/docs/quick-start/es-cluster-demo.yaml
+++ b/docs/quick-start/es-cluster-demo.yaml
@@ -13,7 +13,7 @@ spec:
 
   pilotImage:
     repository: quay.io/jetstack/navigator-pilot-elasticsearch
-    tag: v0.1.0-alpha.1
+    tag: v0.1.0
     pullPolicy: Always
 
   nodePools:


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps version numbers in manifests for v0.1

**Release note**:
```release-note
NONE
```
